### PR TITLE
feat: ZCL command codecs

### DIFF
--- a/zigbee-cluster-library/src/common/data_types.rs
+++ b/zigbee-cluster-library/src/common/data_types.rs
@@ -1,9 +1,73 @@
 //! Data types
 //!
 //! See section 2.6.2
+use core::mem::size_of;
+
 use byte::BytesExt;
 use byte::TryRead;
 use byte::TryWrite;
+
+fn read_uint(bytes: &[u8], len: usize) -> Result<u64, byte::Error> {
+    if len == 0 || len > size_of::<u64>() {
+        return Err(bad_input!("invalid integer width"));
+    }
+
+    let src = bytes.get(..len).ok_or(byte::Error::Incomplete)?;
+    let mut raw = [0u8; 8];
+    raw[..len].copy_from_slice(src);
+    Ok(u64::from_le_bytes(raw))
+}
+
+fn read_int(bytes: &[u8], len: usize) -> Result<i64, byte::Error> {
+    if len == 0 || len > size_of::<i64>() {
+        return Err(bad_input!("invalid integer width"));
+    }
+
+    let value = read_uint(bytes, len)?;
+    let shift = 64 - (len * 8);
+    Ok((value << shift) as i64 >> shift)
+}
+
+fn write_uint(bytes: &mut [u8], value: u64, len: usize) -> Result<usize, byte::Error> {
+    if len == 0 || len > size_of::<u64>() {
+        return Err(bad_input!("invalid integer width"));
+    }
+
+    let max = if len == size_of::<u64>() {
+        u64::MAX
+    } else {
+        (1u64 << (len * 8)) - 1
+    };
+    if value > max {
+        return Err(bad_input!("integer value exceeds encoded width"));
+    }
+
+    bytes
+        .get_mut(..len)
+        .ok_or(byte::Error::Incomplete)?
+        .copy_from_slice(&value.to_le_bytes()[..len]);
+    Ok(len)
+}
+
+fn write_int(bytes: &mut [u8], value: i64, len: usize) -> Result<usize, byte::Error> {
+    if len == 0 || len > size_of::<i64>() {
+        return Err(bad_input!("invalid integer width"));
+    }
+
+    let bits = len * 8;
+    let min = -(1i128 << (bits - 1));
+    let max = (1i128 << (bits - 1)) - 1;
+    let value_i128 = i128::from(value);
+    if value_i128 < min || value_i128 > max {
+        return Err(bad_input!("integer value exceeds encoded width"));
+    }
+
+    bytes
+        .get_mut(..len)
+        .ok_or(byte::Error::Incomplete)?
+        .copy_from_slice(&value.to_le_bytes()[..len]);
+    Ok(len)
+}
 
 #[derive(Debug, PartialEq)]
 pub enum ZclDataType<'a> {
@@ -16,14 +80,41 @@ pub enum ZclDataType<'a> {
     Enum(EnumN),
     Float(FloatN),
     String(ZclString<'a>),
+    /// Not implemented
     Array(&'a [Self]),
+    /// Not implemented
     Structure(&'a [Self]),
+    /// Not implemented
     Set(&'a [Self]),
+    /// Not implemented
     Bag(&'a [Self]),
     Time(TimeType),
     Identifier(IdentifierType),
     Misc(MiscType<'a>),
     Unknown,
+}
+
+impl ZclDataType<'_> {
+    pub fn type_id(&self) -> Result<u8, byte::Error> {
+        match self {
+            Self::NoData => Ok(0x00),
+            Self::Data(value) => Ok(value.type_id()),
+            Self::Bool(_) => Ok(0x10),
+            Self::Bitmap(value) => Ok(value.type_id()),
+            Self::UnsignedInt(value) => Ok(value.type_id()),
+            Self::SignedInt(value) => Ok(value.type_id()),
+            Self::Enum(value) => Ok(value.type_id()),
+            Self::Float(value) => Ok(value.type_id()),
+            Self::String(value) => Ok(value.type_id()),
+            Self::Time(value) => Ok(value.type_id()),
+            Self::Identifier(value) => Ok(value.type_id()),
+            Self::Misc(value) => Ok(value.type_id()),
+            Self::Array(_) | Self::Structure(_) | Self::Set(_) | Self::Bag(_) => {
+                Err(bad_input!("unimplemented ZCL data type"))
+            }
+            Self::Unknown => Err(bad_input!("unsupported ZCL data type")),
+        }
+    }
 }
 
 impl<'a> TryRead<'a, u8> for ZclDataType<'a> {
@@ -32,13 +123,22 @@ impl<'a> TryRead<'a, u8> for ZclDataType<'a> {
         let v = match identifier {
             0x00 => Self::NoData,
             0x08..=0x0F => Self::Data(bytes.read_with(offset, identifier)?),
-            0x10 => Self::Bool(bytes.read(offset)?),
+            0x10 => {
+                let raw: u8 = bytes.read(offset)?;
+                match raw {
+                    0x00 => Self::Bool(false),
+                    0x01 => Self::Bool(true),
+                    _ => return Err(bad_input!("invalid ZCL boolean value")),
+                }
+            }
             0x18..=0x1F => Self::Bitmap(bytes.read_with(offset, identifier)?),
             0x20..=0x27 => Self::UnsignedInt(bytes.read_with(offset, identifier)?),
             0x28..=0x2F => Self::SignedInt(bytes.read_with(offset, identifier)?),
             0x30 | 0x31 => Self::Enum(bytes.read_with(offset, identifier)?),
             0x38..=0x3A => Self::Float(bytes.read_with(offset, identifier)?),
             0x41..=0x44 => Self::String(bytes.read_with(offset, identifier)?),
+            // still need to handle these variants
+            // could use an iterator/lazy parser or over-engineer a visitor pattern maybe?
             //0x48 => Self::Array(bytes.read_with(offset, identifier)?),
             //0x4C => Self::Structure(bytes.read_with(offset, identifier)?),
             //0x50 => Self::Set(bytes.read_with(offset, identifier)?),
@@ -46,7 +146,7 @@ impl<'a> TryRead<'a, u8> for ZclDataType<'a> {
             0xE0..=0xE2 => Self::Time(bytes.read_with(offset, identifier)?),
             0xE8..=0xEA => Self::Identifier(bytes.read_with(offset, identifier)?),
             0xF0 | 0xF1 => Self::Misc(bytes.read_with(offset, identifier)?),
-            _ => Self::Unknown,
+            _ => return Err(bad_input!("unsupported ZCL data type")),
         };
 
         Ok((v, *offset))
@@ -54,8 +154,25 @@ impl<'a> TryRead<'a, u8> for ZclDataType<'a> {
 }
 
 impl TryWrite<u8> for ZclDataType<'_> {
-    fn try_write(self, _bytes: &mut [u8], _identifier: u8) -> Result<usize, ::byte::Error> {
-        unimplemented!()
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match self {
+            Self::NoData if identifier == 0x00 => Ok(0),
+            Self::Data(value) => value.try_write(bytes, identifier),
+            Self::Bool(value) if identifier == 0x10 => {
+                *bytes.first_mut().ok_or(byte::Error::Incomplete)? = u8::from(value);
+                Ok(1)
+            }
+            Self::Bitmap(value) => value.try_write(bytes, identifier),
+            Self::UnsignedInt(value) => value.try_write(bytes, identifier),
+            Self::SignedInt(value) => value.try_write(bytes, identifier),
+            Self::Enum(value) => value.try_write(bytes, identifier),
+            Self::Float(value) => value.try_write(bytes, identifier),
+            Self::String(value) => value.try_write(bytes, identifier),
+            Self::Time(value) => value.try_write(bytes, identifier),
+            Self::Identifier(value) => value.try_write(bytes, identifier),
+            Self::Misc(value) => value.try_write(bytes, identifier),
+            _ => Err(bad_input!("ZCL data type does not match identifier")),
+        }
     }
 }
 
@@ -78,20 +195,62 @@ impl<'a> TryRead<'a, u8> for DataN {
         let v = match identifier {
             0x08 => Self::Data8(bytes.read(offset)?),
             0x09 => Self::Data16(bytes.read(offset)?),
-            0x0A => Self::Data24(bytes.read(offset)?),
-            0x0B => Self::Data32(bytes.read(offset)?),
-            0x0C => Self::Data40(bytes.read(offset)?),
-            0x0D => Self::Data48(bytes.read(offset)?),
-            0x0E => Self::Data56(bytes.read(offset)?),
-            0x0F => Self::Data64(bytes.read(offset)?),
-            _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid DataN",
-                })
+            0x0A => {
+                *offset = 3;
+                Self::Data24(
+                    u32::try_from(read_uint(bytes, 3)?)
+                        .map_err(|_| bad_input!("invalid Data24"))?,
+                )
             }
+            0x0B => Self::Data32(bytes.read(offset)?),
+            0x0C => {
+                *offset = 5;
+                Self::Data40(read_uint(bytes, 5)?)
+            }
+            0x0D => {
+                *offset = 6;
+                Self::Data48(read_uint(bytes, 6)?)
+            }
+            0x0E => {
+                *offset = 7;
+                Self::Data56(read_uint(bytes, 7)?)
+            }
+            0x0F => Self::Data64(bytes.read(offset)?),
+            _ => return Err(bad_input!("invalid DataN")),
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl DataN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Data8(_) => 0x08,
+            Self::Data16(_) => 0x09,
+            Self::Data24(_) => 0x0A,
+            Self::Data32(_) => 0x0B,
+            Self::Data40(_) => 0x0C,
+            Self::Data48(_) => 0x0D,
+            Self::Data56(_) => 0x0E,
+            Self::Data64(_) => 0x0F,
+        }
+    }
+}
+
+impl TryWrite<u8> for DataN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x08, Self::Data8(value)) => value.try_write(bytes, byte::LE),
+            (0x09, Self::Data16(value)) => value.try_write(bytes, byte::LE),
+            (0x0A, Self::Data24(value)) => write_uint(bytes, u64::from(value), 3),
+            (0x0B, Self::Data32(value)) => value.try_write(bytes, byte::LE),
+            (0x0C, Self::Data40(value)) => write_uint(bytes, value, 5),
+            (0x0D, Self::Data48(value)) => write_uint(bytes, value, 6),
+            (0x0E, Self::Data56(value)) => write_uint(bytes, value, 7),
+            (0x0F, Self::Data64(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("DataN does not match identifier")),
+        }
     }
 }
 
@@ -112,22 +271,64 @@ impl<'a> TryRead<'a, u8> for BitmapN {
     fn try_read(bytes: &'a [u8], identifier: u8) -> Result<(Self, usize), ::byte::Error> {
         let offset = &mut 0;
         let v = match identifier {
-            0x08 => Self::Bitmap8(bytes.read(offset)?),
-            0x09 => Self::Bitmap16(bytes.read(offset)?),
-            0x0A => Self::Bitmap24(bytes.read(offset)?),
-            0x0B => Self::Bitmap32(bytes.read(offset)?),
-            0x0C => Self::Bitmap40(bytes.read(offset)?),
-            0x0D => Self::Bitmap48(bytes.read(offset)?),
-            0x0E => Self::Bitmap56(bytes.read(offset)?),
-            0x0F => Self::Bitmap64(bytes.read(offset)?),
-            _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid BitmapN",
-                })
+            0x18 => Self::Bitmap8(bytes.read(offset)?),
+            0x19 => Self::Bitmap16(bytes.read(offset)?),
+            0x1A => {
+                *offset = 3;
+                Self::Bitmap24(
+                    u32::try_from(read_uint(bytes, 3)?)
+                        .map_err(|_| bad_input!("invalid Bitmap24"))?,
+                )
             }
+            0x1B => Self::Bitmap32(bytes.read(offset)?),
+            0x1C => {
+                *offset = 5;
+                Self::Bitmap40(read_uint(bytes, 5)?)
+            }
+            0x1D => {
+                *offset = 6;
+                Self::Bitmap48(read_uint(bytes, 6)?)
+            }
+            0x1E => {
+                *offset = 7;
+                Self::Bitmap56(read_uint(bytes, 7)?)
+            }
+            0x1F => Self::Bitmap64(bytes.read(offset)?),
+            _ => return Err(bad_input!("invalid BitmapN")),
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl BitmapN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Bitmap8(_) => 0x18,
+            Self::Bitmap16(_) => 0x19,
+            Self::Bitmap24(_) => 0x1A,
+            Self::Bitmap32(_) => 0x1B,
+            Self::Bitmap40(_) => 0x1C,
+            Self::Bitmap48(_) => 0x1D,
+            Self::Bitmap56(_) => 0x1E,
+            Self::Bitmap64(_) => 0x1F,
+        }
+    }
+}
+
+impl TryWrite<u8> for BitmapN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x18, Self::Bitmap8(value)) => value.try_write(bytes, byte::LE),
+            (0x19, Self::Bitmap16(value)) => value.try_write(bytes, byte::LE),
+            (0x1A, Self::Bitmap24(value)) => write_uint(bytes, u64::from(value), 3),
+            (0x1B, Self::Bitmap32(value)) => value.try_write(bytes, byte::LE),
+            (0x1C, Self::Bitmap40(value)) => write_uint(bytes, value, 5),
+            (0x1D, Self::Bitmap48(value)) => write_uint(bytes, value, 6),
+            (0x1E, Self::Bitmap56(value)) => write_uint(bytes, value, 7),
+            (0x1F, Self::Bitmap64(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("BitmapN does not match identifier")),
+        }
     }
 }
 
@@ -150,20 +351,62 @@ impl<'a> TryRead<'a, u8> for UnsignedN {
         let v = match identifier {
             0x20 => Self::Uint8(bytes.read(offset)?),
             0x21 => Self::Uint16(bytes.read(offset)?),
-            0x22 => Self::Uint24(bytes.read(offset)?),
-            0x23 => Self::Uint32(bytes.read(offset)?),
-            0x24 => Self::Uint40(bytes.read(offset)?),
-            0x25 => Self::Uint48(bytes.read(offset)?),
-            0x26 => Self::Uint56(bytes.read(offset)?),
-            0x27 => Self::Uint64(bytes.read(offset)?),
-            _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid UnsignedN",
-                })
+            0x22 => {
+                *offset = 3;
+                Self::Uint24(
+                    u32::try_from(read_uint(bytes, 3)?)
+                        .map_err(|_| bad_input!("invalid Uint24"))?,
+                )
             }
+            0x23 => Self::Uint32(bytes.read(offset)?),
+            0x24 => {
+                *offset = 5;
+                Self::Uint40(read_uint(bytes, 5)?)
+            }
+            0x25 => {
+                *offset = 6;
+                Self::Uint48(read_uint(bytes, 6)?)
+            }
+            0x26 => {
+                *offset = 7;
+                Self::Uint56(read_uint(bytes, 7)?)
+            }
+            0x27 => Self::Uint64(bytes.read(offset)?),
+            _ => return Err(bad_input!("invalid UnsignedN")),
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl UnsignedN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Uint8(_) => 0x20,
+            Self::Uint16(_) => 0x21,
+            Self::Uint24(_) => 0x22,
+            Self::Uint32(_) => 0x23,
+            Self::Uint40(_) => 0x24,
+            Self::Uint48(_) => 0x25,
+            Self::Uint56(_) => 0x26,
+            Self::Uint64(_) => 0x27,
+        }
+    }
+}
+
+impl TryWrite<u8> for UnsignedN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x20, Self::Uint8(value)) => value.try_write(bytes, byte::LE),
+            (0x21, Self::Uint16(value)) => value.try_write(bytes, byte::LE),
+            (0x22, Self::Uint24(value)) => write_uint(bytes, u64::from(value), 3),
+            (0x23, Self::Uint32(value)) => value.try_write(bytes, byte::LE),
+            (0x24, Self::Uint40(value)) => write_uint(bytes, value, 5),
+            (0x25, Self::Uint48(value)) => write_uint(bytes, value, 6),
+            (0x26, Self::Uint56(value)) => write_uint(bytes, value, 7),
+            (0x27, Self::Uint64(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("UnsignedN does not match identifier")),
+        }
     }
 }
 
@@ -186,20 +429,61 @@ impl<'a> TryRead<'a, u8> for SignedN {
         let v = match identifier {
             0x28 => Self::Int8(bytes.read(offset)?),
             0x29 => Self::Int16(bytes.read(offset)?),
-            0x2A => Self::Int24(bytes.read(offset)?),
-            0x2B => Self::Int32(bytes.read(offset)?),
-            0x2C => Self::Int40(bytes.read(offset)?),
-            0x2D => Self::Int48(bytes.read(offset)?),
-            0x2E => Self::Int56(bytes.read(offset)?),
-            0x2F => Self::Int64(bytes.read(offset)?),
-            _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid SignedN",
-                })
+            0x2A => {
+                *offset = 3;
+                Self::Int24(
+                    i32::try_from(read_int(bytes, 3)?).map_err(|_| bad_input!("invalid Int24"))?,
+                )
             }
+            0x2B => Self::Int32(bytes.read(offset)?),
+            0x2C => {
+                *offset = 5;
+                Self::Int40(read_int(bytes, 5)?)
+            }
+            0x2D => {
+                *offset = 6;
+                Self::Int48(read_int(bytes, 6)?)
+            }
+            0x2E => {
+                *offset = 7;
+                Self::Int56(read_int(bytes, 7)?)
+            }
+            0x2F => Self::Int64(bytes.read(offset)?),
+            _ => return Err(bad_input!("invalid SignedN")),
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl SignedN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Int8(_) => 0x28,
+            Self::Int16(_) => 0x29,
+            Self::Int24(_) => 0x2A,
+            Self::Int32(_) => 0x2B,
+            Self::Int40(_) => 0x2C,
+            Self::Int48(_) => 0x2D,
+            Self::Int56(_) => 0x2E,
+            Self::Int64(_) => 0x2F,
+        }
+    }
+}
+
+impl TryWrite<u8> for SignedN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x28, Self::Int8(value)) => value.try_write(bytes, byte::LE),
+            (0x29, Self::Int16(value)) => value.try_write(bytes, byte::LE),
+            (0x2A, Self::Int24(value)) => write_int(bytes, i64::from(value), 3),
+            (0x2B, Self::Int32(value)) => value.try_write(bytes, byte::LE),
+            (0x2C, Self::Int40(value)) => write_int(bytes, value, 5),
+            (0x2D, Self::Int48(value)) => write_int(bytes, value, 6),
+            (0x2E, Self::Int56(value)) => write_int(bytes, value, 7),
+            (0x2F, Self::Int64(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("SignedN does not match identifier")),
+        }
     }
 }
 
@@ -217,13 +501,30 @@ impl<'a> TryRead<'a, u8> for EnumN {
             0x30 => Self::Enum8(bytes.read(offset)?),
             0x31 => Self::Enum16(bytes.read(offset)?),
             _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid EnumN",
-                })
+                return Err(bad_input!("invalid EnumN"));
             }
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl EnumN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Enum8(_) => 0x30,
+            Self::Enum16(_) => 0x31,
+        }
+    }
+}
+
+impl TryWrite<u8> for EnumN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x30, Self::Enum8(value)) => value.try_write(bytes, byte::LE),
+            (0x31, Self::Enum16(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("EnumN does not match identifier")),
+        }
     }
 }
 
@@ -245,13 +546,32 @@ impl<'a> TryRead<'a, u8> for FloatN {
             0x39 => Self::Single(bytes.read(offset)?),
             0x3A => Self::Double(bytes.read(offset)?),
             _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid FloatN",
-                })
+                return Err(bad_input!("invalid FloatN"));
             }
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl FloatN {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::Semi(_) => 0x38,
+            Self::Single(_) => 0x39,
+            Self::Double(_) => 0x3A,
+        }
+    }
+}
+
+impl TryWrite<u8> for FloatN {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x38, Self::Semi(value)) => value.try_write(bytes, byte::LE),
+            (0x39, Self::Single(value)) => value.try_write(bytes, byte::LE),
+            (0x3A, Self::Double(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("FloatN does not match identifier")),
+        }
     }
 }
 
@@ -270,20 +590,144 @@ pub enum ZclString<'a> {
 
 impl<'a> TryRead<'a, u8> for ZclString<'a> {
     fn try_read(bytes: &'a [u8], identifier: u8) -> Result<(Self, usize), ::byte::Error> {
-        let offset = &mut 0;
-        let v = match identifier {
-            // 0x41 => Self::OctetString(bytes.read::<&'a [u8]>(offset)?),
-            0x42 => Self::CharString(bytes.read::<&'a str>(offset)?),
-            // 0x43 => Self::LongOctetString(bytes.read::<&'a [u8]>(offset)?),
-            0x44 => Self::LongCharString(bytes.read::<&'a str>(offset)?),
-            _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid ZclString",
-                })
+        match identifier {
+            0x41 => {
+                let len = usize::from(*bytes.first().ok_or(byte::Error::Incomplete)?);
+                if len == 0xff {
+                    return Err(bad_input!("invalid octet string length"));
+                }
+                let end = 1 + len;
+                let value = bytes.get(1..end).ok_or(byte::Error::Incomplete)?;
+                Ok((Self::OctetString(value), end))
             }
-        };
+            0x42 => {
+                let len = usize::from(*bytes.first().ok_or(byte::Error::Incomplete)?);
+                if len == 0xff {
+                    return Err(bad_input!("invalid character string length"));
+                }
+                let end = 1 + len;
+                let raw = bytes.get(1..end).ok_or(byte::Error::Incomplete)?;
+                let value = core::str::from_utf8(raw)
+                    .map_err(|_| bad_input!("invalid character string"))?;
+                Ok((Self::CharString(value), end))
+            }
+            0x43 => {
+                if bytes.len() < 2 {
+                    return Err(byte::Error::Incomplete);
+                }
+                let len = usize::from(u16::from_le_bytes([bytes[0], bytes[1]]));
+                if len == 0xffff {
+                    return Err(bad_input!("invalid long octet string length"));
+                }
+                let end = 2 + len;
+                let value = bytes.get(2..end).ok_or(byte::Error::Incomplete)?;
+                Ok((Self::LongOctetString(value), end))
+            }
+            0x44 => {
+                if bytes.len() < 2 {
+                    return Err(byte::Error::Incomplete);
+                }
+                let len = usize::from(u16::from_le_bytes([bytes[0], bytes[1]]));
+                if len == 0xffff {
+                    return Err(bad_input!("invalid long character string length"));
+                }
+                let end = 2 + len;
+                let raw = bytes.get(2..end).ok_or(byte::Error::Incomplete)?;
+                let value = core::str::from_utf8(raw)
+                    .map_err(|_| bad_input!("invalid long character string"))?;
+                Ok((Self::LongCharString(value), end))
+            }
+            _ => Err(bad_input!("invalid ZclString")),
+        }
+    }
+}
 
-        Ok((v, *offset))
+impl ZclString<'_> {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::OctetString(_) => 0x41,
+            Self::CharString(_) => 0x42,
+            Self::LongOctetString(_) => 0x43,
+            Self::LongCharString(_) => 0x44,
+        }
+    }
+}
+
+impl TryWrite<u8> for ZclString<'_> {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0x41, Self::OctetString(value)) => {
+                let len =
+                    u8::try_from(value.len()).map_err(|_| bad_input!("octet string too long"))?;
+                if len == 0xff {
+                    return Err(bad_input!("octet string length 0xFF is reserved as null"));
+                }
+                *bytes.first_mut().ok_or(byte::Error::Incomplete)? = len;
+                let end = 1 + usize::from(len);
+                bytes
+                    .get_mut(1..end)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(value);
+                Ok(end)
+            }
+            (0x42, Self::CharString(value)) => {
+                let raw = value.as_bytes();
+                let len =
+                    u8::try_from(raw.len()).map_err(|_| bad_input!("character string too long"))?;
+                if len == 0xff {
+                    return Err(bad_input!(
+                        "character string length 0xFF is reserved as null"
+                    ));
+                }
+                *bytes.first_mut().ok_or(byte::Error::Incomplete)? = len;
+                let end = 1 + usize::from(len);
+                bytes
+                    .get_mut(1..end)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(raw);
+                Ok(end)
+            }
+            (0x43, Self::LongOctetString(value)) => {
+                let len = u16::try_from(value.len())
+                    .map_err(|_| bad_input!("long octet string too long"))?;
+                if len == 0xffff {
+                    return Err(bad_input!(
+                        "long octet string length 0xFFFF is reserved as null"
+                    ));
+                }
+                bytes
+                    .get_mut(..2)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(&len.to_le_bytes());
+                let end = 2 + usize::from(len);
+                bytes
+                    .get_mut(2..end)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(value);
+                Ok(end)
+            }
+            (0x44, Self::LongCharString(value)) => {
+                let raw = value.as_bytes();
+                let len = u16::try_from(raw.len())
+                    .map_err(|_| bad_input!("long character string too long"))?;
+                if len == 0xffff {
+                    return Err(bad_input!(
+                        "long character string length 0xFFFF is reserved as null"
+                    ));
+                }
+                bytes
+                    .get_mut(..2)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(&len.to_le_bytes());
+                let end = 2 + usize::from(len);
+                bytes
+                    .get_mut(2..end)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(raw);
+                Ok(end)
+            }
+            _ => Err(bad_input!("ZclString does not match identifier")),
+        }
     }
 }
 
@@ -305,13 +749,32 @@ impl<'a> TryRead<'a, u8> for TimeType {
             0xE1 => Self::Date(bytes.read(offset)?),
             0xE2 => Self::UTCTime(bytes.read(offset)?),
             _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid TimeType",
-                })
+                return Err(bad_input!("invalid TimeType"));
             }
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl TimeType {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::TimeOfDay(_) => 0xE0,
+            Self::Date(_) => 0xE1,
+            Self::UTCTime(_) => 0xE2,
+        }
+    }
+}
+
+impl TryWrite<u8> for TimeType {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0xE0, Self::TimeOfDay(value))
+            | (0xE1, Self::Date(value))
+            | (0xE2, Self::UTCTime(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("TimeType does not match identifier")),
+        }
     }
 }
 
@@ -333,13 +796,33 @@ impl<'a> TryRead<'a, u8> for IdentifierType {
             0xE9 => Self::AttributeId(bytes.read(offset)?),
             0xEA => Self::BACnetOid(bytes.read(offset)?),
             _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid IdentifierType",
-                })
+                return Err(bad_input!("invalid IdentifierType"));
             }
         };
 
         Ok((v, *offset))
+    }
+}
+
+impl IdentifierType {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::ClusterId(_) => 0xE8,
+            Self::AttributeId(_) => 0xE9,
+            Self::BACnetOid(_) => 0xEA,
+        }
+    }
+}
+
+impl TryWrite<u8> for IdentifierType {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0xE8, Self::ClusterId(value)) | (0xE9, Self::AttributeId(value)) => {
+                value.try_write(bytes, byte::LE)
+            }
+            (0xEA, Self::BACnetOid(value)) => value.try_write(bytes, byte::LE),
+            _ => Err(bad_input!("IdentifierType does not match identifier")),
+        }
     }
 }
 
@@ -356,11 +839,17 @@ impl<'a> TryRead<'a, u8> for MiscType<'a> {
         let offset = &mut 0;
         let v = match identifier {
             0xF0 => MiscType::IeeeAddress(bytes.read(offset)?),
-            // 0xF1 => MiscType::SecurityKey(bytes.read(offset)?),
+            0xF1 => {
+                let raw: &'a [u8; 16] = bytes
+                    .get(..16)
+                    .ok_or(byte::Error::Incomplete)?
+                    .try_into()
+                    .map_err(|_| bad_input!("invalid security key length"))?;
+                *offset = 16;
+                MiscType::SecurityKey(raw)
+            }
             _ => {
-                return Err(byte::Error::BadInput {
-                    err: "invalid MiscType",
-                })
+                return Err(bad_input!("invalid MiscType"));
             }
         };
 
@@ -368,9 +857,35 @@ impl<'a> TryRead<'a, u8> for MiscType<'a> {
     }
 }
 
+impl MiscType<'_> {
+    pub fn type_id(&self) -> u8 {
+        match self {
+            Self::IeeeAddress(_) => 0xF0,
+            Self::SecurityKey(_) => 0xF1,
+        }
+    }
+}
+
+impl TryWrite<u8> for MiscType<'_> {
+    fn try_write(self, bytes: &mut [u8], identifier: u8) -> Result<usize, ::byte::Error> {
+        match (identifier, self) {
+            (0xF0, Self::IeeeAddress(value)) => value.try_write(bytes, byte::LE),
+            (0xF1, Self::SecurityKey(value)) => {
+                bytes
+                    .get_mut(..16)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(value);
+                Ok(16)
+            }
+            _ => Err(bad_input!("MiscType does not match identifier")),
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use byte::TryRead;
+    use byte::TryWrite;
 
     use super::ZclDataType;
     use crate::common::data_types::DataN;
@@ -378,7 +893,9 @@ mod tests {
     use crate::common::data_types::FloatN;
     use crate::common::data_types::IdentifierType;
     use crate::common::data_types::MiscType;
+    use crate::common::data_types::SignedN;
     use crate::common::data_types::TimeType;
+    use crate::common::data_types::UnsignedN;
     use crate::common::data_types::ZclString;
 
     #[test]
@@ -424,7 +941,7 @@ mod tests {
         assert_eq!(len, 1);
         assert!(matches!(data, ZclDataType::Bool(_)));
         if let ZclDataType::Bool(value) = data {
-            assert_eq!(value, true);
+            assert!(value);
         } else {
             panic!("ZclDataType::Bool expected!");
         }
@@ -466,16 +983,16 @@ mod tests {
         }
     }
 
-    // #[test] // 💥 Parsing the input fails
+    #[test]
     fn parse_string() {
         // given
-        let input: &[u8] = &[0x48, 0x65, 0x6C, 0x6C, 0x6F];
+        let input: &[u8] = &[0x05, b'H', b'e', b'l', b'l', b'o'];
 
         // when
         let (data, len) = ZclDataType::try_read(input, 0x42).unwrap();
 
         // then
-        assert_eq!(len, 2);
+        assert_eq!(len, input.len());
         assert!(matches!(data, ZclDataType::String(_)));
         if let ZclDataType::String(value) = data {
             assert_eq!(value, ZclString::CharString("Hello"));
@@ -496,7 +1013,7 @@ mod tests {
         // assert_eq!(len, 2);
         assert!(matches!(data, ZclDataType::Time(_)));
         if let ZclDataType::Time(value) = data {
-            assert_eq!(value, TimeType::UTCTime(1179586589));
+            assert_eq!(value, TimeType::UTCTime(1_179_586_589));
         } else {
             panic!("TimeType::UTCTime expected!");
         }
@@ -538,5 +1055,133 @@ mod tests {
         } else {
             panic!("MiscType::IeeeAddress expected!");
         }
+    }
+
+    #[test]
+    fn octet_string_roundtrips() {
+        let mut buf = [0u8; 8];
+        let payload: &[u8] = &[0xDE, 0xAD, 0xBE];
+
+        let write_len = ZclDataType::String(ZclString::OctetString(payload))
+            .try_write(&mut buf, 0x41)
+            .unwrap();
+        assert_eq!(write_len, 4);
+        assert_eq!(&buf[..write_len], &[0x03, 0xDE, 0xAD, 0xBE]);
+
+        let (value, read_len) = ZclDataType::try_read(&buf[..write_len], 0x41).unwrap();
+        assert_eq!(read_len, 4);
+        assert_eq!(value, ZclDataType::String(ZclString::OctetString(payload)));
+    }
+
+    #[test]
+    fn long_octet_string_roundtrips() {
+        let mut buf = [0u8; 8];
+        let payload: &[u8] = &[0xCA, 0xFE];
+
+        let write_len = ZclDataType::String(ZclString::LongOctetString(payload))
+            .try_write(&mut buf, 0x43)
+            .unwrap();
+        assert_eq!(write_len, 4);
+        assert_eq!(&buf[..write_len], &[0x02, 0x00, 0xCA, 0xFE]);
+
+        let (value, read_len) = ZclDataType::try_read(&buf[..write_len], 0x43).unwrap();
+        assert_eq!(read_len, 4);
+        assert_eq!(
+            value,
+            ZclDataType::String(ZclString::LongOctetString(payload))
+        );
+    }
+
+    #[test]
+    fn long_char_string_roundtrips() {
+        let mut buf = [0u8; 16];
+
+        let write_len = ZclDataType::String(ZclString::LongCharString("Hello"))
+            .try_write(&mut buf, 0x44)
+            .unwrap();
+        assert_eq!(write_len, 7);
+        assert_eq!(
+            &buf[..write_len],
+            &[0x05, 0x00, b'H', b'e', b'l', b'l', b'o']
+        );
+
+        let (value, read_len) = ZclDataType::try_read(&buf[..write_len], 0x44).unwrap();
+        assert_eq!(read_len, 7);
+        assert_eq!(
+            value,
+            ZclDataType::String(ZclString::LongCharString("Hello"))
+        );
+    }
+
+    #[test]
+    fn char_string_null_indicator_rejected_on_write() {
+        let raw = [b'a'; 255];
+        let s = core::str::from_utf8(&raw).unwrap();
+        let mut buf = [0u8; 260];
+        assert!(
+            ZclDataType::String(ZclString::CharString(s))
+                .try_write(&mut buf, 0x42)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn octet_string_null_indicator_rejected_on_write() {
+        let payload = [0u8; 255];
+        let mut buf = [0u8; 260];
+        assert!(
+            ZclDataType::String(ZclString::OctetString(&payload))
+                .try_write(&mut buf, 0x41)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn writes_non_standard_width_integers_without_truncation() {
+        let mut buf = [0u8; 8];
+
+        let len = ZclDataType::UnsignedInt(UnsignedN::Uint24(0x12_34_56))
+            .try_write(&mut buf, 0x22)
+            .unwrap();
+        assert_eq!(len, 3);
+        assert_eq!(&buf[..len], &[0x56, 0x34, 0x12]);
+
+        let (value, read) = ZclDataType::try_read(&buf[..len], 0x22).unwrap();
+        assert_eq!(read, 3);
+        assert_eq!(
+            value,
+            ZclDataType::UnsignedInt(UnsignedN::Uint24(0x12_34_56))
+        );
+
+        let len = ZclDataType::SignedInt(SignedN::Int24(-2))
+            .try_write(&mut buf, 0x2A)
+            .unwrap();
+        assert_eq!(len, 3);
+        assert_eq!(&buf[..len], &[0xFE, 0xFF, 0xFF]);
+
+        let (value, read) = ZclDataType::try_read(&buf[..len], 0x2A).unwrap();
+        assert_eq!(read, 3);
+        assert_eq!(value, ZclDataType::SignedInt(SignedN::Int24(-2)));
+    }
+
+    #[test]
+    fn non_standard_width_writes_reject_out_of_range_values() {
+        let mut buf = [0u8; 8];
+
+        assert!(
+            ZclDataType::UnsignedInt(UnsignedN::Uint24(0x01_00_00_00))
+                .try_write(&mut buf, 0x22)
+                .is_err()
+        );
+        assert!(
+            ZclDataType::SignedInt(SignedN::Int24(0x0080_0000))
+                .try_write(&mut buf, 0x2A)
+                .is_err()
+        );
+        assert!(
+            ZclDataType::SignedInt(SignedN::Int24(-0x0080_0001))
+                .try_write(&mut buf, 0x2A)
+                .is_err()
+        );
     }
 }

--- a/zigbee-cluster-library/src/frame.rs
+++ b/zigbee-cluster-library/src/frame.rs
@@ -1,10 +1,10 @@
 //! General ZCL Frame
 #![allow(missing_docs)]
-#![allow(clippy::panic)]
 
-use byte::ctx;
 use byte::BytesExt;
 use byte::TryRead;
+use byte::TryWrite;
+use byte::ctx;
 use heapless::Vec;
 use zigbee_macros::impl_byte;
 
@@ -16,7 +16,7 @@ impl_byte! {
     /// ZCL Frame
     ///
     /// See Section 2.4.1
-    #[derive(Debug)]
+    #[derive(Debug, PartialEq)]
     pub struct ZclFrame<'a> {
         pub header: ZclHeader,
         #[ctx = &header]
@@ -25,11 +25,236 @@ impl_byte! {
     }
 }
 
-#[derive(Debug)]
-pub enum GeneralCommand<'a> {
-    ReadAttributesCommand(Vec<ReadAttribute, 16>),
-    ReportAttributesCommand(Vec<AttributeReport<'a>, 16>),
-    // ...
+/// Status enumeration
+///
+/// See Section 2.6.3
+///
+/// The spec notes that deprecated values should not be used in a transmitted
+/// message and received values should be processed as if the value were the
+/// replacement status value instead. For compatibility, the replacements will
+/// be performed when serializing or deserializing from bytes.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[repr(u8)]
+pub enum Status {
+    /// Operation was successful.
+    Success = 0x00,
+    /// Operation was not successful.
+    Failure = 0x01,
+    /// The sender of the command does not have authorization to carry out this
+    /// command.
+    NotAuthorized = 0x7e,
+    Reserved = 0x7f,
+    /// The command appears to contain the wrong fields, as detected either by
+    /// the presence of one or more invalid field entries or by there being
+    /// missing fields. Command not carried out. Implementer has discretion as
+    /// to whether to return this error or [`Status::InvalidField`].
+    MalformedCommand = 0x80,
+    /// The specified command is not supported on the device. Command not
+    /// carried out.
+    UnsupCommand = 0x81,
+    /// ~The specified general ZCL command is not supported on the device.~
+    ///
+    /// Use [`Status::UnsupCommand`]
+    #[deprecated(note = "Use `Status::UnsupCommand`")]
+    UnsupGeneralCommand = 0x82,
+    /// ~A manufacturer specific unicast, cluster specific command was received
+    /// with an unknown manufacturer code, or the manufacturer code was
+    /// recognized but the command is not supported.~
+    ///
+    /// Use [`Status::UnsupCommand`]
+    #[deprecated = "Use `Status::UnsupCommand`"]
+    UnsupManufClusterCommand = 0x83,
+    /// ~A manufacturer specific unicast, ZCL specific command was received with
+    /// an unknown manufacturer code, or the manufacturer code was recognized
+    /// but the command is not supported.~
+    ///
+    /// Use [`Status::UnsupCommand`]
+    #[deprecated = "Use `Status::UnsupCommand`"]
+    UnsupManufGeneralCommand = 0x84,
+    /// At least one field of the command contains an incorrect value, according
+    /// to the specification the device is implemented to
+    InvalidField = 0x85,
+    /// The specified attribute does not exist on the device.
+    UnsupportedAttribute = 0x86,
+    /// Out of range error or set to a reserved value. Attribute keeps its old
+    /// value.
+    ///
+    /// Note that an attribute value may be out of range if an attribute is
+    /// related to another, e.g., with minimum and maximum attributes. See the
+    /// individual attribute descriptions for specific details.
+    InvalidValue = 0x87,
+    /// Attempt to write a read-only attribute.
+    ReadOnly = 0x88,
+    /// An operation failed due to an insufficient amount of free space
+    /// available.
+    InsufficientSpace = 0x89,
+    /// ~An attempt to create an entry in a table failed due to a duplicate
+    /// entry already being present in the table.~
+    ///
+    /// Use [`Status::Success`]
+    #[deprecated = "Use `Status::Success`"]
+    DuplicateExists = 0x8a,
+    /// The requested information (e.g., table entry) could not be found.
+    NotFound = 0x8b,
+    /// Periodic reports cannot be issued for this attribute.
+    UnreportableAttribute = 0x8c,
+    /// The data type given for an attribute is incorrect. Command not carried
+    /// out.
+    InvalidDataType = 0x8d,
+    /// The selector for an attribute is incorrect.
+    InvalidSelector = 0x8e,
+    /// ~A request has been made to read an attribute that the requestor is not
+    /// authorized to read. No action taken.~
+    ///
+    /// Use [`Status::NotAuthorized`]
+    #[deprecated = "Use Status::NotAuthorized"]
+    WriteOnly = 0x8f,
+    /// ~Setting the requested values would put the device in an inconsistent
+    /// state on startup. No action taken.~
+    ///
+    /// Use [`Status::Failure`]
+    #[deprecated = "Use `Status::Failure`"]
+    InconsistentStartupState = 0x90,
+    /// ~An attempt has been made to write an attribute that is present but is
+    /// defined using an out-of-band method and not over the air.~
+    ///
+    /// Use [`Status::Failure`]
+    #[deprecated = "Use `Status::Failure`"]
+    DefinedOutOfBand = 0x91,
+    /// The supplied values (e.g., contents of table cells) are inconsistent.
+    ///
+    /// Never used.
+    ReservedInconsistent = 0x92,
+    /// ~The credentials presented by the device sending the command are not
+    /// sufficient to perform this action.~
+    ///
+    /// Use [`Status::Failure`]
+    #[deprecated = "Use `Status::Failure`"]
+    ActionDenied = 0x93,
+    /// The exchange was aborted due to excessive response time.
+    Timeout = 0x94,
+    /// Failed case when a client or a server decides to abort the upgrade
+    /// process.
+    Abort = 0x95,
+    /// Invalid OTA upgrade image (ex. failed signature validation or signer
+    /// information check or CRC check).
+    InvalidImage = 0x96,
+    /// Server does not have data block available yet.
+    WaitForData = 0x97,
+    /// No OTA upgrade image available for the client.
+    NoImageAvailable = 0x98,
+    /// The client still requires more OTA upgrade image files to successfully
+    /// upgrade.
+    RequireMoreImage = 0x99,
+    /// The command has been received and is being processed.
+    NotificationPending = 0x9a,
+    /// ~An operation was unsuccessful due to a hardware failure.~
+    ///
+    /// Use [`Status::Failure`]
+    #[deprecated = "Use `Status::Failure`"]
+    HardwareFailure = 0xc0,
+    /// ~An operation was unsuccessful due to a software failure.~
+    ///
+    /// Use [`Status::Failure`]
+    #[deprecated = "Use `Status::Failure`"]
+    SoftwareFailure = 0xc1,
+    /// An error occurred during calibration.
+    ///
+    /// Never used.
+    ReservedCalibration = 0xc2,
+    /// The cluster is not supported.
+    UnsupportedCluster = 0xc3,
+    /// ~Limit of attribute range reached. Value is trimmed to closest limit
+    /// (maximum or minimum).~
+    ///
+    /// Use [`Status::Success`]
+    #[deprecated = "Use `Status::Success`"]
+    LimitReached = 0xc4,
+    Unknown,
+}
+
+impl Status {
+    fn from_byte(b: u8) -> byte::Result<Self> {
+        match b {
+            0x00 => Ok(Self::Success),
+            0x01 => Ok(Self::Failure),
+            0x7e => Ok(Self::NotAuthorized),
+            0x7f => Ok(Self::Reserved),
+            0x80 => Ok(Self::MalformedCommand),
+            0x81 => Ok(Self::UnsupCommand),
+            0x85 => Ok(Self::InvalidField),
+            0x86 => Ok(Self::UnsupportedAttribute),
+            0x87 => Ok(Self::InvalidValue),
+            0x88 => Ok(Self::ReadOnly),
+            0x89 => Ok(Self::InsufficientSpace),
+            0x8b => Ok(Self::NotFound),
+            0x8c => Ok(Self::UnreportableAttribute),
+            0x8d => Ok(Self::InvalidDataType),
+            0x8e => Ok(Self::InvalidSelector),
+            0x92 => Ok(Self::ReservedInconsistent),
+            0x94 => Ok(Self::Timeout),
+            0x95 => Ok(Self::Abort),
+            0x96 => Ok(Self::InvalidImage),
+            0x97 => Ok(Self::WaitForData),
+            0x98 => Ok(Self::NoImageAvailable),
+            0x99 => Ok(Self::RequireMoreImage),
+            0x9a => Ok(Self::NotificationPending),
+            0xc2 => Ok(Self::ReservedCalibration),
+            0xc3 => Ok(Self::UnsupportedCluster),
+            _ => Err(bad_input!("unknown ZCL status byte")),
+        }
+    }
+}
+
+impl<'a> TryRead<'a, ()> for Status {
+    fn try_read(bytes: &'a [u8], _: ()) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let raw: u8 = bytes.read_with(offset, ctx::LE)?;
+        // Errata: deprecated wire bytes are substituted for their replacements.
+        let status = match raw {
+            0x82 | 0x83 | 0x84 => Self::UnsupCommand,
+            0x8a | 0xc4 => Self::Success,
+            0x8f => Self::NotAuthorized,
+            0x90 | 0x91 | 0x93 | 0xc0 | 0xc1 => Self::Failure,
+            other => Self::from_byte(other)?,
+        };
+        Ok((status, *offset))
+    }
+}
+
+#[allow(deprecated)]
+impl TryWrite<()> for Status {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        // Errata: deprecated variants are substituted for their replacements on the
+        // wire.
+        let raw: u8 = match self {
+            Self::Unknown => return Err(bad_input!("unknown ZCL status")),
+            Self::UnsupGeneralCommand
+            | Self::UnsupManufClusterCommand
+            | Self::UnsupManufGeneralCommand => Self::UnsupCommand as u8,
+            Self::DuplicateExists | Self::LimitReached => Self::Success as u8,
+            Self::WriteOnly => Self::NotAuthorized as u8,
+            Self::InconsistentStartupState
+            | Self::DefinedOutOfBand
+            | Self::ActionDenied
+            | Self::HardwareFailure
+            | Self::SoftwareFailure => Self::Failure as u8,
+            other => other as u8,
+        };
+        bytes.write_with(offset, raw, ctx::LE)?;
+        Ok(*offset)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum GeneralCommand<'a, const CMD_ATTR_CAPACITY: usize = 16> {
+    ReadAttributes(Vec<ReadAttribute, CMD_ATTR_CAPACITY>),
+    ReadAttributesResponse(Vec<ReadAttributeResponse<'a>, CMD_ATTR_CAPACITY>),
+    WriteAttributes(Vec<WriteAttribute<'a>, CMD_ATTR_CAPACITY>),
+    WriteAttributesResponse(Vec<WriteAttributeStatus, CMD_ATTR_CAPACITY>),
+    ReportAttributes(Vec<AttributeReport<'a>, CMD_ATTR_CAPACITY>),
+    DefaultResponse(DefaultResponse),
 }
 
 impl_byte! {
@@ -40,9 +265,171 @@ impl_byte! {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct ReadAttributeResponse<'a> {
+    pub attribute_id: u16,
+    pub status: Status,
+    pub value: Option<ZclDataType<'a>>,
+}
+
+impl<'a> TryRead<'a, ()> for ReadAttributeResponse<'a> {
+    fn try_read(bytes: &'a [u8], _: ()) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let attribute_id = bytes.read_with(offset, ctx::LE)?;
+        let status: Status = bytes.read_with(offset, ())?;
+        let value = if status == Status::Success {
+            let data_type: u8 = bytes.read_with(offset, ctx::LE)?;
+            Some(bytes.read_with(offset, data_type)?)
+        } else {
+            None
+        };
+
+        Ok((
+            Self {
+                attribute_id,
+                status,
+                value,
+            },
+            *offset,
+        ))
+    }
+}
+
+impl TryWrite<()> for ReadAttributeResponse<'_> {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        bytes.write_with(offset, self.attribute_id, ctx::LE)?;
+        bytes.write_with(offset, self.status, ())?;
+        if self.status == Status::Success {
+            let value = self.value.ok_or(bad_input!(
+                "successful ReadAttributeResponse requires value"
+            ))?;
+            let type_id = value.type_id()?;
+            bytes.write_with(offset, type_id, ctx::LE)?;
+            bytes.write_with(offset, value, type_id)?;
+        } else if self.value.is_some() {
+            return Err(bad_input!(
+                "failed ReadAttributeResponse must not include value"
+            ));
+        }
+        Ok(*offset)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct WriteAttribute<'a> {
+    pub attribute_id: u16,
+    pub value: ZclDataType<'a>,
+}
+
+impl<'a> TryRead<'a, ()> for WriteAttribute<'a> {
+    fn try_read(bytes: &'a [u8], _: ()) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let attribute_id = bytes.read_with(offset, ctx::LE)?;
+        let data_type_id: u8 = bytes.read_with(offset, ctx::LE)?;
+        let data_type = bytes.read_with(offset, data_type_id)?;
+
+        Ok((
+            Self {
+                attribute_id,
+                value: data_type,
+            },
+            *offset,
+        ))
+    }
+}
+
+impl TryWrite<()> for WriteAttribute<'_> {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        let data_type_id = self.value.type_id()?;
+        bytes.write_with(offset, self.attribute_id, ctx::LE)?;
+        bytes.write_with(offset, data_type_id, ctx::LE)?;
+        bytes.write_with(offset, self.value, data_type_id)?;
+        Ok(*offset)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WriteAttributeStatus {
+    pub status: Status,
+    pub attribute_id: Option<u16>,
+}
+
+impl<'a> TryRead<'a, ()> for WriteAttributeStatus {
+    fn try_read(bytes: &'a [u8], _: ()) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let status: Status = bytes.read_with(offset, ())?;
+        let attribute_id = if status == Status::Success {
+            None
+        } else {
+            Some(bytes.read_with(offset, ctx::LE)?)
+        };
+        Ok((
+            Self {
+                status,
+                attribute_id,
+            },
+            *offset,
+        ))
+    }
+}
+
+impl TryWrite<()> for WriteAttributeStatus {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        bytes.write_with(offset, self.status, ())?;
+        match (self.status, self.attribute_id) {
+            (Status::Success, None) => {}
+            (Status::Success, Some(_)) => {
+                return Err(bad_input!(
+                    "successful WriteAttributeStatus must not include attribute id"
+                ));
+            }
+            (_, Some(attribute_id)) => bytes.write_with(offset, attribute_id, ctx::LE)?,
+            (_, None) => {
+                return Err(bad_input!(
+                    "failed WriteAttributeStatus requires attribute id"
+                ));
+            }
+        }
+        Ok(*offset)
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct DefaultResponse {
+    pub command_identifier: u8,
+    pub status: Status,
+}
+
+impl<'a> TryRead<'a, ()> for DefaultResponse {
+    fn try_read(bytes: &'a [u8], _: ()) -> byte::Result<(Self, usize)> {
+        let offset = &mut 0;
+        let command_identifier = bytes.read_with(offset, ctx::LE)?;
+        let status = bytes.read_with(offset, ())?;
+        Ok((
+            Self {
+                command_identifier,
+                status,
+            },
+            *offset,
+        ))
+    }
+}
+
+impl TryWrite<()> for DefaultResponse {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        bytes.write_with(offset, self.command_identifier, ctx::LE)?;
+        bytes.write_with(offset, self.status, ())?;
+        Ok(*offset)
+    }
+}
+
+#[derive(Debug, PartialEq)]
 pub struct AttributeReport<'a> {
     pub attribute_id: u16,
-    pub data_type: ZclDataType<'a>,
+    pub value: ZclDataType<'a>,
 }
 
 impl<'a> TryRead<'a, ()> for AttributeReport<'a> {
@@ -54,27 +441,35 @@ impl<'a> TryRead<'a, ()> for AttributeReport<'a> {
 
         let report = Self {
             attribute_id,
-            data_type: data,
+            value: data,
         };
 
         Ok((report, *offset))
     }
 }
 
-#[allow(missing_docs)]
-pub struct ClusterSpecificCommand<'a> {
-    /// ZCL Header
-    pub header: ZclHeader,
-    /// ZCL Payload
-    pub payload: &'a [u8],
+impl TryWrite<()> for AttributeReport<'_> {
+    fn try_write(self, bytes: &mut [u8], _: ()) -> byte::Result<usize> {
+        let offset = &mut 0;
+        let data_type_id = self.value.type_id()?;
+        bytes.write_with(offset, self.attribute_id, ctx::LE)?;
+        bytes.write_with(offset, data_type_id, ctx::LE)?;
+        bytes.write_with(offset, self.value, data_type_id)?;
+        Ok(*offset)
+    }
 }
 
 #[cfg(test)]
 mod tests {
+    #![allow(clippy::panic)]
     use byte::TryRead;
+    use byte::TryWrite;
 
     use super::*;
+    use crate::common::data_types::EnumN;
     use crate::common::data_types::SignedN;
+    use crate::common::data_types::UnsignedN;
+    use crate::common::data_types::ZclString;
 
     #[test]
     fn parse_attribute_report_payload() {
@@ -90,10 +485,7 @@ mod tests {
 
         // then
         assert_eq!(report.attribute_id, 0u16);
-        assert_eq!(
-            report.data_type,
-            ZclDataType::SignedInt(SignedN::Int16(939))
-        );
+        assert_eq!(report.value, ZclDataType::SignedInt(SignedN::Int16(939)));
     }
 
     #[allow(clippy::panic)]
@@ -111,16 +503,15 @@ mod tests {
         let (frame, _) = ZclFrame::try_read(input, ()).expect("Failed to read ZclFrame");
 
         // then
-        let _expected = &[0x00, 0x00, 0x29, 0x3f, 0x0a];
         assert!(matches!(frame.payload, ZclFramePayload::GeneralCommand(_)));
 
         if let ZclFramePayload::GeneralCommand(cmd) = frame.payload {
-            if let GeneralCommand::ReportAttributesCommand(report) = cmd {
+            if let GeneralCommand::ReportAttributes(report) = cmd {
                 assert_eq!(report.len(), 1);
                 let attribute_report = report.first().expect("Expected ONE report in test");
                 assert_eq!(attribute_report.attribute_id, 0u16);
                 assert_eq!(
-                    attribute_report.data_type,
+                    attribute_report.value,
                     ZclDataType::SignedInt(SignedN::Int16(2623))
                 );
             } else {
@@ -156,5 +547,407 @@ mod tests {
         } else {
             panic!("ClusterSpecificCommand expected!");
         }
+    }
+
+    #[test]
+    fn read_attributes_frame_roundtrips() {
+        let input: &[u8] = &[
+            0x00, // frame control: global, client to server
+            0x11, // sequence number
+            0x00, // Read Attributes
+            0x00, 0x00, // ZCLVersion
+            0x04, 0x00, // ManufacturerName
+        ];
+
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("read attributes request parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributes(attrs)) = &frame.payload
+        else {
+            panic!("ReadAttributesCommand expected");
+        };
+        assert_eq!(attrs.len(), 2);
+        assert_eq!(attrs[0].attribute_id, 0x0000);
+        assert_eq!(attrs[1].attribute_id, 0x0004);
+
+        let mut output = [0u8; 16];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("read attributes request writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn write_attributes_frame_roundtrips() {
+        let input: &[u8] = &[
+            0x00, // frame control: global, client to server
+            0x12, // sequence number
+            0x02, // Write Attributes
+            0x01, 0x00, // attribute id
+            0x10, // boolean
+            0x01, // true
+            0x02, 0x00, // attribute id
+            0x42, // character string
+            0x02, b'O', b'K',
+        ];
+
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("write attributes request parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributes(attrs)) =
+            &frame.payload
+        else {
+            panic!("WriteAttributesCommand expected");
+        };
+        assert_eq!(attrs.len(), 2);
+        assert_eq!(attrs[0].value, ZclDataType::Bool(true));
+        assert_eq!(
+            attrs[1].value,
+            ZclDataType::String(ZclString::CharString("OK"))
+        );
+
+        let mut output = [0u8; 32];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("write attributes request writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn basic_cluster_read_attributes_response_writes_spec_records() {
+        let mut records = Vec::<ReadAttributeResponse<'_>, 16>::new();
+        records
+            .push(ReadAttributeResponse {
+                attribute_id: 0x0000, // ZCLVersion
+                status: Status::Success,
+                value: Some(ZclDataType::UnsignedInt(UnsignedN::Uint8(8))),
+            })
+            .unwrap();
+        records
+            .push(ReadAttributeResponse {
+                attribute_id: 0x0007, // PowerSource
+                status: Status::Success,
+                value: Some(ZclDataType::Enum(EnumN::Enum8(0x03))),
+            })
+            .unwrap();
+        records
+            .push(ReadAttributeResponse {
+                attribute_id: 0x0004, // ManufacturerName
+                status: Status::Success,
+                value: Some(ZclDataType::String(ZclString::CharString("Acme"))),
+            })
+            .unwrap();
+
+        let frame = ZclFrame {
+            header: ZclHeader {
+                frame_control: crate::header::frame_control::FrameControl(0x18),
+                manufacturer_code: None,
+                sequence_number: 0x22,
+                command_identifier:
+                    crate::header::command_identifier::CommandIdentifier::ReadAttributesResponse,
+            },
+            payload: ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(
+                records,
+            )),
+        };
+
+        let expected: &[u8] = &[
+            0x18, 0x22, 0x01, // header
+            0x00, 0x00, 0x00, 0x20, 0x08, // ZCLVersion: success, uint8, 8
+            0x07, 0x00, 0x00, 0x30, 0x03, // PowerSource: success, enum8, battery
+            0x04, 0x00, 0x00, 0x42, 0x04, b'A', b'c', b'm', b'e',
+        ];
+
+        let mut output = [0u8; 32];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("basic cluster read response writes");
+        assert_eq!(written, expected.len());
+        assert_eq!(&output[..written], expected);
+
+        let (parsed, parsed_len) =
+            ZclFrame::try_read(&output[..written], ()).expect("basic cluster read response parses");
+        assert_eq!(parsed_len, expected.len());
+        assert_eq!(parsed.header.sequence_number, 0x22);
+    }
+
+    #[test]
+    fn write_attributes_response_all_success_roundtrips() {
+        // All writes succeeded: single SUCCESS record, no attribute id.
+        let input: &[u8] = &[
+            0x18, // frame control: global, server to client, default response disabled
+            0x13, // sequence number
+            0x04, // Write Attributes Response
+            0x00, // SUCCESS — attribute id omitted
+        ];
+
+        let (frame, len) =
+            ZclFrame::try_read(input, ()).expect("all-success write response parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributesResponse(ref records)) =
+            frame.payload
+        else {
+            panic!("WriteAttributesResponse expected");
+        };
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, Status::Success);
+        assert!(records[0].attribute_id.is_none());
+
+        let mut output = [0u8; 8];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("all-success write response writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn write_attributes_response_failure_records_roundtrip() {
+        // Some writes failed: only the failed records are present, each with attribute
+        // id.
+        let input: &[u8] = &[
+            0x18, // frame control: global, server to client, default response disabled
+            0x14, // sequence number
+            0x04, // Write Attributes Response
+            0x86, // UNSUPPORTED_ATTRIBUTE
+            0x99, 0x88, // attribute id
+        ];
+
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("failure write response parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributesResponse(ref records)) =
+            frame.payload
+        else {
+            panic!("WriteAttributesResponse expected");
+        };
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].status, Status::UnsupportedAttribute);
+        assert_eq!(records[0].attribute_id, Some(0x8899));
+
+        let mut output = [0u8; 16];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("failure write response writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn write_attributes_response_parses_mixed_success_and_failure_gracefully() {
+        // Non-compliant senders may mix SUCCESS with failures; parse gracefully.
+        let input: &[u8] = &[
+            0x18, // frame control
+            0x15, // sequence number
+            0x04, // Write Attributes Response
+            0x00, // SUCCESS record — no attr id
+            0x86, // UNSUPPORTED_ATTRIBUTE record
+            0x01, 0x00, // attribute id
+        ];
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("mixed response parses gracefully");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributesResponse(ref records)) =
+            frame.payload
+        else {
+            panic!("WriteAttributesResponse expected");
+        };
+        assert_eq!(records.len(), 2);
+        assert_eq!(records[0].status, Status::Success);
+        assert!(records[0].attribute_id.is_none());
+        assert_eq!(records[1].status, Status::UnsupportedAttribute);
+        assert_eq!(records[1].attribute_id, Some(0x0001));
+    }
+
+    #[test]
+    fn write_attributes_response_normalizes_mixed_to_failures_on_write() {
+        // TryWrite drops SUCCESS records when failures are present.
+        let mut records = Vec::<WriteAttributeStatus, 16>::new();
+        records
+            .push(WriteAttributeStatus {
+                status: Status::Success,
+                attribute_id: None,
+            })
+            .unwrap();
+        records
+            .push(WriteAttributeStatus {
+                status: Status::UnsupportedAttribute,
+                attribute_id: Some(0x0001),
+            })
+            .unwrap();
+
+        let frame = ZclFrame {
+            header: ZclHeader {
+                frame_control: crate::header::frame_control::FrameControl(0x18),
+                manufacturer_code: None,
+                sequence_number: 0x20,
+                command_identifier:
+                    crate::header::command_identifier::CommandIdentifier::WriteAttributesResponse,
+            },
+            payload: ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributesResponse(
+                records,
+            )),
+        };
+
+        let mut buf = [0u8; 16];
+        let written = frame
+            .try_write(&mut buf, ())
+            .expect("normalizes mixed on write");
+        let expected: &[u8] = &[
+            0x18, 0x20, 0x04, // header
+            0x86, 0x01, 0x00, // UNSUPPORTED_ATTRIBUTE for attribute 0x0001
+        ];
+        assert_eq!(&buf[..written], expected);
+    }
+
+    #[test]
+    fn write_attributes_response_normalizes_multiple_success_to_single() {
+        // Multiple SUCCESS records collapse to a single SUCCESS on write.
+        let mut records = Vec::<WriteAttributeStatus, 16>::new();
+        records
+            .push(WriteAttributeStatus {
+                status: Status::Success,
+                attribute_id: None,
+            })
+            .unwrap();
+        records
+            .push(WriteAttributeStatus {
+                status: Status::Success,
+                attribute_id: None,
+            })
+            .unwrap();
+
+        let frame = ZclFrame {
+            header: ZclHeader {
+                frame_control: crate::header::frame_control::FrameControl(0x18),
+                manufacturer_code: None,
+                sequence_number: 0x20,
+                command_identifier:
+                    crate::header::command_identifier::CommandIdentifier::WriteAttributesResponse,
+            },
+            payload: ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributesResponse(
+                records,
+            )),
+        };
+
+        let mut buf = [0u8; 8];
+        let written = frame
+            .try_write(&mut buf, ())
+            .expect("normalizes multiple success");
+        let expected: &[u8] = &[
+            0x18, 0x20, 0x04, // header
+            0x00, // single SUCCESS
+        ];
+        assert_eq!(&buf[..written], expected);
+    }
+
+    #[test]
+    fn unsupported_attribute_data_type_is_rejected() {
+        let input: &[u8] = &[
+            0x18, // frame control: global, server to client
+            0x15, // sequence number
+            0x01, // Read Attributes Response
+            0x00, 0x00, // attribute id
+            0x00, // success
+            0x48, // array: unsupported until structured types are implemented
+        ];
+
+        assert!(ZclFrame::try_read(input, ()).is_err());
+    }
+
+    #[test]
+    fn default_response_roundtrips() {
+        let input: &[u8] = &[
+            0x18, // frame control: global, server to client, default response disabled
+            0x14, // sequence number
+            0x0b, // Default Response
+            0x00, // command identifier being responded to: Read Attributes
+            0x00, // success
+        ];
+
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("default response parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::DefaultResponse(ref dr)) = frame.payload
+        else {
+            panic!("DefaultResponse expected");
+        };
+        assert_eq!(dr.command_identifier, 0x00); // Read Attributes
+        assert_eq!(dr.status, Status::Success);
+
+        let mut output = [0u8; 8];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("default response writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn default_response_rejects_unrecognized_status_byte() {
+        let input: &[u8] = &[
+            0x18, // frame control
+            0x14, // sequence number
+            0x0b, // Default Response
+            0x02, // command identifier: Write Attributes
+            0x7d, // unrecognized status byte
+        ];
+
+        assert!(ZclFrame::try_read(input, ()).is_err());
+    }
+
+    #[test]
+    fn read_attribute_response_failure_record_roundtrips() {
+        let input: &[u8] = &[
+            0x18, // frame control: global, server to client
+            0x16, // sequence number
+            0x01, // Read Attributes Response
+            0x00, 0x00, // attribute id: ZCLVersion
+            0x86, // UNSUPPORTED_ATTRIBUTE — no data type or value follows
+        ];
+
+        let (frame, len) = ZclFrame::try_read(input, ()).expect("failure record parses");
+        assert_eq!(len, input.len());
+
+        let ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(ref records)) =
+            frame.payload
+        else {
+            panic!("ReadAttributesResponse expected");
+        };
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].attribute_id, 0x0000);
+        assert_eq!(records[0].status, Status::UnsupportedAttribute);
+        assert!(records[0].value.is_none());
+
+        let mut output = [0u8; 16];
+        let written = frame
+            .try_write(&mut output, ())
+            .expect("failure record writes");
+        assert_eq!(written, input.len());
+        assert_eq!(&output[..written], input);
+    }
+
+    #[test]
+    fn read_attribute_response_rejects_inconsistent_status_value_combinations() {
+        let mut buf = [0u8; 16];
+
+        // success status requires a value on write
+        let no_value = ReadAttributeResponse {
+            attribute_id: 0x0000,
+            status: Status::Success,
+            value: None,
+        };
+        assert!(no_value.try_write(&mut buf, ()).is_err());
+
+        // failure status must not carry a value on write
+        let spurious_value = ReadAttributeResponse {
+            attribute_id: 0x0000,
+            status: Status::UnsupportedAttribute,
+            value: Some(ZclDataType::UnsignedInt(UnsignedN::Uint8(0))),
+        };
+        assert!(spurious_value.try_write(&mut buf, ()).is_err());
     }
 }

--- a/zigbee-cluster-library/src/header/command_identifier.rs
+++ b/zigbee-cluster-library/src/header/command_identifier.rs
@@ -80,14 +80,30 @@ impl TryWrite<byte::ctx::Endian> for CommandIdentifier {
     }
 }
 
+#[macro_export]
+macro_rules! test_branches_command_identifier {
+    ($($name:ident: $input:expr => $want:expr,)+) => {
+        $(
+            #[test]
+            fn $name() {
+                // when
+                let (command_identifier, _) = CommandIdentifier::try_read($input, byte::LE)
+                    .expect("Could not read CommandIdentifier in test");
+
+                // then
+                assert_eq!(command_identifier, $want);
+            }
+        )+
+    };
+}
+
 #[cfg(test)]
 mod tests {
     use byte::TryRead;
 
     use super::*;
-    use crate::test_branches_command_identifier;
 
-    test_branches_command_identifier! {
+    crate::test_branches_command_identifier! {
         cmd_ident_read_attributes: &[0x00] => CommandIdentifier::ReadAttributes,
         cmd_ident_read_attributes_response: &[0x01] => CommandIdentifier::ReadAttributesResponse,
         cmd_ident_write_attributes: &[0x02] => CommandIdentifier::WriteAttributes,
@@ -112,21 +128,4 @@ mod tests {
         cmd_ident_discoverattributesextended: &[0x15] => CommandIdentifier::DiscoverAttributesExtended,
         cmd_ident_discoverattributesextendedresponse: &[0x16] => CommandIdentifier::DiscoverAttributesExtendedResponse,
     }
-}
-
-#[macro_export]
-macro_rules! test_branches_command_identifier {
-    ($($name:ident: $input:expr => $want:expr,)+) => {
-        $(
-            #[test]
-            fn $name() {
-                // when
-                let (command_identifier, _) = CommandIdentifier::try_read($input, byte::LE)
-                    .expect("Could not read CommandIdentifier in test");
-
-                // then
-                assert_eq!(command_identifier, $want);
-            }
-        )+
-    };
 }

--- a/zigbee-cluster-library/src/header/frame_control.rs
+++ b/zigbee-cluster-library/src/header/frame_control.rs
@@ -1,7 +1,6 @@
 //! Frame Control
 use core::fmt;
 use core::fmt::Debug;
-use core::mem;
 
 use zigbee_macros::impl_byte;
 
@@ -25,18 +24,19 @@ pub enum FrameType {
 
 impl FrameControl {
     /// See Section 2.4.1.1.1
-    ///
-    /// Returns `true` if command is global
     pub fn frame_type(self) -> FrameType {
-        // SAFETY: any 2 bit permutation is a valid FrameType
-        unsafe { mem::transmute((self.0 & mask::FRAME_TYPE) >> offset::FRAME_TYPE) }
+        match (self.0 & mask::FRAME_TYPE) >> offset::FRAME_TYPE {
+            0b00 => FrameType::GlobalCommand,
+            0b01 => FrameType::ClusterCommand,
+            _ => FrameType::Reserved,
+        }
     }
 
     /// The Manufacturer Specific field specifies whether this command refers to
     /// a manufacturer specific extension.
     ///
     /// If this value is set to 1, the manufacturer code field SHALL be present
-    /// in the ``ZCLframe``.
+    /// in the ``ZclFrame``.
     ///
     /// See Section 2.4.1.1.2
     pub fn is_manufacturer_specific(self) -> bool {
@@ -134,6 +134,15 @@ mod tests {
         assert!(frame_control.direction());
         assert!(frame_control.disable_default_response());
     }
+    #[test]
+    fn frame_type_reserved_covers_both_reserved_values() {
+        // Frame type bits 0b10 and 0b11 are both Reserved per spec.
+        let fc_10 = FrameControl(0b0000_0010);
+        let fc_11 = FrameControl(0b0000_0011);
+        assert_eq!(fc_10.frame_type(), FrameType::Reserved);
+        assert_eq!(fc_11.frame_type(), FrameType::Reserved);
+    }
+
     #[test]
     fn frame_control_with_direction_server_to_client() {
         // given

--- a/zigbee-cluster-library/src/lib.rs
+++ b/zigbee-cluster-library/src/lib.rs
@@ -1,7 +1,9 @@
-//! Implements the `ZigBee` Cluster Library in `no-std` based on the [ZigBee Cluster Library Rev 8]
+//! Implements the `ZigBee` Cluster Library in `no-std` based on the [ZigBee
+//! Cluster Library Rev 8]
 //!
-//! This crate defines application-level behaviors, like reading attributes, reporting, and commands.
-//! It contains standard clusters like Temperature Measurement, Basic Identify, etc.
+//! This crate defines application-level behaviors, like reading attributes,
+//! reporting, and commands. It contains standard clusters like Temperature
+//! Measurement, Basic Identify, etc.
 //!
 //! [ZigBee Cluster Library Rev 8]: https://csa-iot.org/wp-content/uploads/2022/01/07-5123-08-Zigbee-Cluster-Library-1.pdf
 #![no_std]
@@ -32,16 +34,22 @@
     clippy::large_enum_variant,
     clippy::derive_partial_eq_without_eq,
     clippy::too_long_first_doc_paragraph,
-    dead_code,
+    dead_code
 )]
 
-pub(crate) mod common;
+macro_rules! bad_input {
+    ($msg:expr) => {
+        byte::Error::BadInput { err: $msg }
+    };
+}
+
+pub mod common;
 
 /// General ZCL Frame
-pub(crate) mod frame;
-pub(crate) mod payload;
+pub mod frame;
+pub mod payload;
 
-pub(crate) mod header;
+pub mod header;
 
 // Chapter 4
 pub mod measurement;
@@ -51,4 +59,3 @@ pub mod lighting;
 pub mod hvac;
 // Chapter 10
 pub mod energy;
-

--- a/zigbee-cluster-library/src/payload.rs
+++ b/zigbee-cluster-library/src/payload.rs
@@ -3,17 +3,77 @@ use byte::TryRead;
 use byte::TryWrite;
 use heapless::Vec;
 
-use crate::frame::AttributeReport;
 use crate::frame::GeneralCommand;
+use crate::frame::Status;
+use crate::frame::WriteAttributeStatus;
+use crate::header::ZclHeader;
 use crate::header::command_identifier::CommandIdentifier;
 use crate::header::frame_control::FrameType;
-use crate::header::ZclHeader;
 
-#[derive(Debug)]
+#[derive(Debug, PartialEq)]
 pub enum ZclFramePayload<'a> {
     GeneralCommand(GeneralCommand<'a>),
     ClusterSpecificCommand(&'a [u8]),
     Reserved,
+}
+
+fn read_records<'a, T, const N: usize>(
+    bytes: &'a [u8],
+    offset: &mut usize,
+) -> byte::Result<Vec<T, N>>
+where
+    T: TryRead<'a, ()>,
+{
+    let mut records = Vec::new();
+    while *offset < bytes.len() {
+        let record = bytes.read_with(offset, ())?;
+        records
+            .push(record)
+            .map_err(|_| bad_input!("ZCL command record list exceeds capacity"))?;
+    }
+    Ok(records)
+}
+
+/// Normalizes a WriteAttributesResponse for serialization:
+/// - If any failures present: emit only failure records (spec: no SUCCESS mixed in).
+/// - Otherwise (all success or empty): emit a single SUCCESS record with no attribute id.
+fn write_normalized_response<const N: usize>(
+    bytes: &mut [u8],
+    offset: &mut usize,
+    records: Vec<WriteAttributeStatus, N>,
+) -> byte::Result<()> {
+    let has_failures = records.iter().any(|r| r.status != Status::Success);
+    if has_failures {
+        for record in records {
+            if record.status != Status::Success {
+                bytes.write_with(offset, record, ())?;
+            }
+        }
+    } else {
+        bytes.write_with(
+            offset,
+            WriteAttributeStatus {
+                status: Status::Success,
+                attribute_id: None,
+            },
+            (),
+        )?;
+    }
+    Ok(())
+}
+
+fn write_records<T, const N: usize>(
+    bytes: &mut [u8],
+    offset: &mut usize,
+    records: Vec<T, N>,
+) -> byte::Result<()>
+where
+    T: TryWrite<()>,
+{
+    for record in records {
+        bytes.write_with(offset, record, ())?;
+    }
+    Ok(())
 }
 
 impl<'a> TryRead<'a, &ZclHeader> for ZclFramePayload<'a> {
@@ -22,49 +82,73 @@ impl<'a> TryRead<'a, &ZclHeader> for ZclFramePayload<'a> {
         let payload = match header.frame_control.frame_type() {
             FrameType::GlobalCommand => {
                 let cmd = match header.command_identifier {
-                    // ReadAttributes => todo!(),
-                    // ReadAttributesResponse => todo!(),
-                    // WriteAttributes => todo!(),
-                    // WriteAttributesUndivided => todo!(),
-                    // WriteAttributesResponse => todo!(),
-                    // WriteAttributesNoResponse => todo!(),
-                    // ConfigureReporting => todo!(),
-                    // ConfigureReportingResponse => todo!(),
-                    // ReadReportingConfiguration => todo!(),
-                    // ReadReportingConfigurationResponse => todo!(),
-                    CommandIdentifier::ReportAttributes => {
-                        let mut attribute_reports: Vec<AttributeReport<'_>, 16> = Vec::new();
-                        while let Ok(attribute_report) = bytes.read_with(offset, ()) {
-                            attribute_reports.push(attribute_report).unwrap();
-                        }
-                        GeneralCommand::ReportAttributesCommand(attribute_reports)
+                    CommandIdentifier::ReadAttributes => {
+                        GeneralCommand::ReadAttributes(read_records(bytes, offset)?)
                     }
-                    // DefaultResponse => todo!(),
-                    // DiscoverAttributes => todo!(),
-                    // DiscoverAttributesResponse => todo!(),
-                    // ReadAttributesStructured => todo!(),
-                    // WriteAttributesStructured => todo!(),
-                    // WriteAttributesStructuredResponse => todo!(),
-                    // DiscoverCommandsReceived => todo!(),
-                    // DiscoverCommandsReceivedResponse => todo!(),
-                    // DiscoverCommandsGenerated => todo!(),
-                    // DiscoverCommandsGeneratedResponse => todo!(),
-                    // DiscoverAttributesExtended => todo!(),
-                    // DiscoverAttributesExtendedResponse => todo!(),
-                    // Reserved => todo!(),
-                    _ => todo!(),
+                    CommandIdentifier::ReadAttributesResponse => {
+                        GeneralCommand::ReadAttributesResponse(read_records(bytes, offset)?)
+                    }
+                    CommandIdentifier::WriteAttributes => {
+                        GeneralCommand::WriteAttributes(read_records(bytes, offset)?)
+                    }
+                    CommandIdentifier::WriteAttributesResponse => {
+                        GeneralCommand::WriteAttributesResponse(read_records(bytes, offset)?)
+                    }
+                    CommandIdentifier::ReportAttributes => {
+                        GeneralCommand::ReportAttributes(read_records(bytes, offset)?)
+                    }
+                    CommandIdentifier::DefaultResponse => {
+                        GeneralCommand::DefaultResponse(bytes.read_with(offset, ())?)
+                    }
+                    _ => {
+                        return Err(bad_input!("unsupported ZCL global command"));
+                    }
                 };
                 ZclFramePayload::GeneralCommand(cmd)
             }
-            FrameType::ClusterCommand => ZclFramePayload::ClusterSpecificCommand(bytes),
-            FrameType::Reserved => todo!(),
+            FrameType::ClusterCommand => {
+                *offset = bytes.len();
+                ZclFramePayload::ClusterSpecificCommand(bytes)
+            }
+            FrameType::Reserved => {
+                return Err(bad_input!("reserved ZCL frame type"));
+            }
         };
 
         Ok((payload, *offset))
     }
 }
+
 impl TryWrite<()> for ZclFramePayload<'_> {
-    fn try_write(self, _bytes: &mut [u8], _: ()) -> Result<usize, ::byte::Error> {
-        unimplemented!()
+    fn try_write(self, bytes: &mut [u8], _: ()) -> Result<usize, ::byte::Error> {
+        let offset = &mut 0;
+        match self {
+            Self::GeneralCommand(command) => match command {
+                GeneralCommand::ReadAttributes(attrs) => write_records(bytes, offset, attrs)?,
+                GeneralCommand::ReadAttributesResponse(attrs) => {
+                    write_records(bytes, offset, attrs)?
+                }
+                GeneralCommand::WriteAttributes(attrs) => write_records(bytes, offset, attrs)?,
+                GeneralCommand::WriteAttributesResponse(attrs) => {
+                    write_normalized_response(bytes, offset, attrs)?
+                }
+                GeneralCommand::ReportAttributes(attrs) => write_records(bytes, offset, attrs)?,
+                GeneralCommand::DefaultResponse(response) => {
+                    bytes.write_with(offset, response, ())?;
+                }
+            },
+            Self::ClusterSpecificCommand(payload) => {
+                let end = payload.len();
+                bytes
+                    .get_mut(..end)
+                    .ok_or(byte::Error::Incomplete)?
+                    .copy_from_slice(payload);
+                *offset = end;
+            }
+            Self::Reserved => {
+                return Err(bad_input!("reserved ZCL payload"));
+            }
+        }
+        Ok(*offset)
     }
 }


### PR DESCRIPTION
This PR makes ZCL attributes usable via a public API, enabling application code (e.g. BDB) to easily serialize/deserialize ZCL global commands.

`Status` is documented per ZCL rev 8. Deprecated variants are retained in the enum for exhaustiveness and marked `#[deprecated]`; `TryRead`/`TryWrite` apply the spec's substitutions on the wire. It may be better to omit the deprecated fields or never used fields entirely and apply the substitutions during (de)serialization.

`WriteAttributesResponse` normalizes the wire format per spec: failure records omit
any interleaved successes; an all-success response serializes as a single `SUCCESS` with no attr id.

`frame`, `header`, and `payload` are now `pub`. ZCL payload paths that previously panicked should now return `byte::Error::BadInput`.

I tried to keep this unopinionated and additive. Commits are organized by message.