### PR TITLE
chore: complete Z2M device interview for sleepy end devices

### DIFF
--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -107,13 +107,25 @@ fn descriptor_config() -> DeviceDescriptorConfig<'static> {
     }
 }
 
+/// How often the sleepy end device polls its parent for buffered frames.
+/// Must stay well below the parent's ~7.68 s indirect-transaction
+/// persistence time so interview requests are retrieved before they expire.
+const POLL_INTERVAL_MS: u64 = 500;
+
 /// Steady-state receive loop: answers ZDP discovery, Basic-cluster reads, and
-/// Configure Reporting requests.
+/// Configure Reporting requests. Each iteration polls the parent (MLME-POLL) —
+/// as a sleepy end device we only receive unicasts by asking for them — and
+/// then sleeps to pace the data requests.
 #[embassy_executor::task]
 async fn rx_task(device: &'static ZigbeeDevice<EspMlme<'static>>) {
-    device
-        .rx_loop(&descriptor_config(), &(BASIC, ConfigureReportingServer))
-        .await
+    let cfg = descriptor_config();
+    let handler = (BASIC, ConfigureReportingServer);
+    loop {
+        if let Err(e) = device.poll_and_dispatch(&cfg, &handler).await {
+            println!("Rx dispatch error: {e:?}");
+        }
+        Timer::after_millis(POLL_INTERVAL_MS).await;
+    }
 }
 
 #[esp_rtos::main]
@@ -142,6 +154,11 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
     let device: &'static ZigbeeDevice<EspMlme<'static>> =
         DEVICE.init(ZigbeeDevice::new(config, nlme));
     let mut bdb = BaseDeviceBehavior::new(config);
+    // The TC link key exchange polls would consume (and drop) the
+    // coordinator's interview requests right after joining, and this Trust
+    // Center does not answer REQUEST-KEY anyway. Skip it and start the
+    // receive loop immediately so the interview can complete.
+    bdb.tc_link_key_exchange_enabled = false;
 
     println!("Joining EPID={EXTENDED_PAN_ID:#018x} on channel {CHANNEL}...");
     let join = bdb

--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -107,15 +107,12 @@ fn descriptor_config() -> DeviceDescriptorConfig<'static> {
     }
 }
 
-/// How often the sleepy end device polls its parent for buffered frames.
-/// Must stay well below the parent's ~7.68 s indirect-transaction
-/// persistence time so interview requests are retrieved before they expire.
+/// Parent poll interval; must stay below the parent's ~7.68 s
+/// indirect-transaction persistence time.
 const POLL_INTERVAL_MS: u64 = 500;
 
-/// Steady-state receive loop: answers ZDP discovery, Basic-cluster reads, and
-/// Configure Reporting requests. Each iteration polls the parent (MLME-POLL) —
-/// as a sleepy end device we only receive unicasts by asking for them — and
-/// then sleeps to pace the data requests.
+/// Steady-state receive loop: polls the parent and answers ZDP discovery,
+/// Basic-cluster reads, and Configure Reporting requests.
 #[embassy_executor::task]
 async fn rx_task(device: &'static ZigbeeDevice<EspMlme<'static>>) {
     let cfg = descriptor_config();
@@ -154,10 +151,8 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
     let device: &'static ZigbeeDevice<EspMlme<'static>> =
         DEVICE.init(ZigbeeDevice::new(config, nlme));
     let mut bdb = BaseDeviceBehavior::new(config);
-    // The TC link key exchange polls would consume (and drop) the
-    // coordinator's interview requests right after joining, and this Trust
-    // Center does not answer REQUEST-KEY anyway. Skip it and start the
-    // receive loop immediately so the interview can complete.
+    // the tclk exchange polls would eat the coordinator's interview requests
+    // and this trust center never answers REQUEST-KEY anyway
     bdb.tc_link_key_exchange_enabled = false;
 
     println!("Joining EPID={EXTENDED_PAN_ID:#018x} on channel {CHANNEL}...");

--- a/zigbee-base-device-behavior/src/lib.rs
+++ b/zigbee-base-device-behavior/src/lib.rs
@@ -67,6 +67,13 @@ pub struct BaseDeviceBehavior {
     bdb_node_is_on_a_network: bool,
     bdb_commissioning_mode: CommissioningMode,
     bdb_commissioning_status: BdbCommissioningStatus,
+    /// Whether network steering performs the TC link key exchange
+    /// (BDB §8.2 step 12). While the exchange runs, its poll windows consume
+    /// and drop any other frames buffered at the parent — including the
+    /// coordinator's device-interview requests. Disable it to hand control
+    /// back to the application immediately after Device_annce and keep using
+    /// the default global TC link key.
+    pub tc_link_key_exchange_enabled: bool,
 }
 
 impl BaseDeviceBehavior {
@@ -76,6 +83,7 @@ impl BaseDeviceBehavior {
             bdb_node_is_on_a_network: false,
             bdb_commissioning_mode: CommissioningMode::NetworkSteering,
             bdb_commissioning_status: BdbCommissioningStatus::Success,
+            tc_link_key_exchange_enabled: true,
         }
     }
 
@@ -147,9 +155,21 @@ impl BaseDeviceBehavior {
         Self::device_annce(device, capability_information).await?;
 
         // §8.2 step 12, §10.2.5
-        log::debug!("[BDB] step 12: TC link key exchange");
-        self.tc_link_key_exchange(device).await?;
-        log::debug!("[BDB] step 12: TC link key exchange complete");
+        if self.tc_link_key_exchange_enabled {
+            log::debug!("[BDB] step 12: TC link key exchange");
+            // A Trust Center running with default policies (e.g. Z-Stack with
+            // legacy devices allowed) may never answer the REQUEST-KEY. Keep
+            // operating with the default global TC link key in that case — the
+            // node descriptor advertises a pre-r21 stack revision accordingly.
+            match self.tc_link_key_exchange(device).await {
+                Ok(()) => log::debug!("[BDB] step 12: TC link key exchange complete"),
+                Err(e) => log::warn!(
+                    "[BDB] step 12: TC link key exchange failed ({e:?}), continuing with default TC link key"
+                ),
+            }
+        } else {
+            log::debug!("[BDB] step 12: TC link key exchange disabled, skipping");
+        }
 
         self.bdb_node_is_on_a_network = true;
         self.bdb_commissioning_status = BdbCommissioningStatus::Success;
@@ -207,7 +227,7 @@ impl BaseDeviceBehavior {
                     log::debug!("[BDB] received new TC link key");
                     break key_desc.key;
                 }
-                _ if attempts >= BDBC_MAX_SAME_NETWORK_RETRY_ATTEMPTS => {
+                _ if attempts >= BDBC_REC_SAME_NETWORK_RETRY_ATTEMPTS => {
                     log::warn!("[BDB] TC link key exchange failed: no TRANSPORT-KEY");
                     self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
                     return Err(NetworkError::NoTransportKey);

--- a/zigbee-base-device-behavior/src/lib.rs
+++ b/zigbee-base-device-behavior/src/lib.rs
@@ -67,12 +67,9 @@ pub struct BaseDeviceBehavior {
     bdb_node_is_on_a_network: bool,
     bdb_commissioning_mode: CommissioningMode,
     bdb_commissioning_status: BdbCommissioningStatus,
-    /// Whether network steering performs the TC link key exchange
-    /// (BDB §8.2 step 12). While the exchange runs, its poll windows consume
-    /// and drop any other frames buffered at the parent — including the
-    /// coordinator's device-interview requests. Disable it to hand control
-    /// back to the application immediately after Device_annce and keep using
-    /// the default global TC link key.
+    /// Whether network steering performs the TC link key exchange (BDB §8.2
+    /// step 12). Disable to keep the default global TC link key and return
+    /// to the application right after Device_annce.
     pub tc_link_key_exchange_enabled: bool,
 }
 
@@ -157,10 +154,8 @@ impl BaseDeviceBehavior {
         // §8.2 step 12, §10.2.5
         if self.tc_link_key_exchange_enabled {
             log::debug!("[BDB] step 12: TC link key exchange");
-            // A Trust Center running with default policies (e.g. Z-Stack with
-            // legacy devices allowed) may never answer the REQUEST-KEY. Keep
-            // operating with the default global TC link key in that case — the
-            // node descriptor advertises a pre-r21 stack revision accordingly.
+            // non-fatal: a TC allowing legacy devices may never answer the
+            // REQUEST-KEY, keep the default global TC link key then
             match self.tc_link_key_exchange(device).await {
                 Ok(()) => log::debug!("[BDB] step 12: TC link key exchange complete"),
                 Err(e) => log::warn!(

--- a/zigbee-mac/src/esp/driver.rs
+++ b/zigbee-mac/src/esp/driver.rs
@@ -1,13 +1,31 @@
+use embassy_futures::select::Either;
+use embassy_futures::select::select;
 use embassy_sync::blocking_mutex::raw::CriticalSectionRawMutex;
 use embassy_sync::signal::Signal;
+use embassy_time::Timer;
 use esp_hal::efuse;
 use esp_radio::ieee802154::Config;
 use esp_radio::ieee802154::Error as Ieee802154Error;
 use esp_radio::ieee802154::Ieee802154;
 use esp_radio::ieee802154::ReceivedFrame;
 
-static TX_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+use crate::mlme::MacError;
+
+/// Outcome of a transmission, reported by the radio's tx-done / tx-failed
+/// interrupts. `Failed` covers no-ACK (after the hardware's 200 ms ACK wait),
+/// CCA-busy and coex aborts.
+#[derive(Clone, Copy)]
+enum TxEvent {
+    Done,
+    Failed,
+}
+
+static TX_SIGNAL: Signal<CriticalSectionRawMutex, TxEvent> = Signal::new();
 static RX_SIGNAL: Signal<CriticalSectionRawMutex, ()> = Signal::new();
+
+/// Safety net above the hardware's 200 ms ACK wait; with both tx-done and
+/// tx-failed wired, exceeding this means a genuinely lost interrupt.
+const TX_DONE_TIMEOUT_MS: u64 = 250;
 
 /// Derive an EUI-64 extended address from a 6-byte EUI-48 MAC.
 ///
@@ -54,6 +72,9 @@ impl<'a> Ieee802154Driver<'a> {
             .driver
             .set_rx_available_callback_fn(Self::rx_callback);
         driver.driver.set_tx_done_callback_fn(Self::tx_callback);
+        driver
+            .driver
+            .set_tx_failed_callback_fn(Self::tx_failed_callback);
 
         driver.config.rx_when_idle = true;
         driver.config.ext_addr = Some(ieee_address.0);
@@ -84,20 +105,29 @@ impl<'a> Ieee802154Driver<'a> {
     }
 
     fn tx_callback() {
-        TX_SIGNAL.signal(());
+        TX_SIGNAL.signal(TxEvent::Done);
+    }
+
+    fn tx_failed_callback() {
+        TX_SIGNAL.signal(TxEvent::Failed);
     }
 
     /// Transmit a frame. The radio automatically returns to RX mode
     /// after transmission completes (`rx_when_idle = true`).
     ///
-    /// For an acknowledgment-requested frame the transmit-done signal fires
-    /// only after the ACK is received or the hardware ACK-wait times out, so
-    /// [`Self::last_tx_acked`] is valid once this returns.
-    pub async fn transmit(&mut self, frame: &[u8]) -> Result<(), Ieee802154Error> {
+    /// For an acknowledgment-requested frame tx-done fires only once the ACK is
+    /// received, so [`Self::last_tx_acked`] is valid on `Ok`. Returns
+    /// [`MacError::TxFailed`] on no-ACK, CCA-busy or a coex abort.
+    pub async fn transmit(&mut self, frame: &[u8]) -> Result<(), MacError> {
         TX_SIGNAL.reset();
         self.driver.transmit_raw(frame, true)?;
-        TX_SIGNAL.wait().await;
-        Ok(())
+        // bound the wait: a lost interrupt would otherwise block here forever
+        // while holding the radio lock, wedging the whole stack
+        match select(Timer::after_millis(TX_DONE_TIMEOUT_MS), TX_SIGNAL.wait()).await {
+            Either::First(_) => Err(MacError::TxTimeout),
+            Either::Second(TxEvent::Done) => Ok(()),
+            Either::Second(TxEvent::Failed) => Err(MacError::TxFailed),
+        }
     }
 
     /// Whether the most recent transmission was acknowledged. Only meaningful

--- a/zigbee-mac/src/esp/mod.rs
+++ b/zigbee-mac/src/esp/mod.rs
@@ -43,6 +43,9 @@ const ASSOCIATE_REQUEST_RETRIES: u8 = 3;
 /// Number of times the association response is polled per request attempt.
 const ASSOCIATE_POLL_RETRIES: u8 = 5;
 
+/// Number of poll rounds per steady-state MLME-POLL before reporting no data.
+const POLL_DATA_RETRIES: u8 = 5;
+
 /// ESP32-C6 [`Mlme`] implementation.
 ///
 /// The radio is a single shared resource: the inner state is held behind an
@@ -92,9 +95,14 @@ impl EspMlmeInner<'_> {
     /// goes unacknowledged.
     async fn transmit_acked(&mut self, frame: &[u8]) -> Result<(), MacError> {
         for _ in 0..=A_MAX_FRAME_RETRIES {
-            self.driver.transmit(frame).await?;
-            if self.driver.last_tx_acked() {
-                return Ok(());
+            match self.driver.transmit(frame).await {
+                Ok(()) if self.driver.last_tx_acked() => return Ok(()),
+                Ok(()) => {}
+                // no ack / channel busy: retransmit (§7.5.6.4)
+                Err(MacError::TxFailed) => {}
+                // a lost radio interrupt: retry rather than wedge the caller
+                Err(MacError::TxTimeout) => log::warn!("[MLME] tx-done timeout, retrying"),
+                Err(e) => return Err(e),
             }
         }
         Err(MacError::NoAck)
@@ -324,6 +332,51 @@ impl EspMlmeInner<'_> {
         }
     }
 
+    /// Drain the RX queue for one unicast data frame (non-blocking), discarding
+    /// broadcasts and non-data frames. An indirect (poll) response is always a
+    /// unicast, so ambient broadcasts never shadow it.
+    fn take_unicast_data(&mut self, buf: &mut [u8]) -> Result<Option<(usize, u8)>, MacError> {
+        while let Some(result) = self.poll_frame() {
+            let received = result?;
+            if matches!(
+                received.frame.header.destination,
+                Some(Address::Short(_, ieee802154::mac::ShortAddress(d))) if d >= 0xfff8
+            ) {
+                continue;
+            }
+            if let Some(data) = copy_data_payload(received, buf) {
+                return Ok(Some(data));
+            }
+        }
+        Ok(None)
+    }
+
+    /// Wait up to `timeout_us` for one buffered unicast data frame.
+    ///
+    /// Shares [`Self::recv_association_response`]'s timing discipline: it waits
+    /// ~4 ms before each drain (the RX signal may not fire even when a frame is
+    /// queued) and never logs in the loop (the UART critical section stalls the
+    /// RX ISR). Returns `Ok(None)` when the window elapses with nothing for us.
+    async fn recv_data_response(
+        &mut self,
+        timeout_us: u64,
+        buf: &mut [u8],
+    ) -> Result<Option<(usize, u8)>, MacError> {
+        let timeout = Timer::after_micros(timeout_us);
+        let receive = async {
+            loop {
+                Timer::after_micros(4000).await;
+                if let Some(data) = self.take_unicast_data(buf)? {
+                    return Ok::<_, MacError>(Some(data));
+                }
+            }
+        };
+        match embassy_futures::select::select(timeout, receive).await {
+            Either::First(_) => Ok(None),
+            Either::Second(result) => result,
+        }
+    }
+
     fn association_request_frame(
         &mut self,
         dest: Address,
@@ -513,41 +566,31 @@ impl EspMlmeInner<'_> {
         coord_address: Address,
         buf: &mut [u8],
     ) -> Result<(usize, u8), MacError> {
-        self.flush();
-        let (data_req, len) = self.data_request_frame(coord_address)?;
-        // a missing ack means the parent has nothing buffered; still listen
-        match self.transmit_acked(&data_req[..len]).await {
-            Ok(()) | Err(MacError::NoAck) => {}
-            Err(e) => return Err(e),
+        // a response elicited by an earlier poll may have landed after its
+        // listen window closed; deliver it instead of flushing it away
+        if let Some((len, lqi)) = self.take_unicast_data(buf)? {
+            log::debug!("[MLME-POLL] rx buffered data len={len}");
+            return Ok((len, lqi));
         }
-        // arm RX for the response (~2ms after the poll ack); no log here — the
-        // UART critical section stalls the RX ISR
-        self.driver.start_receive();
-
         let timeout_us = (A_RESPONSE_WAIT_TIME as u64) * 16;
-        let timeout = Timer::after_micros(timeout_us);
-        let receive = async {
-            loop {
-                let received = self.next_frame().await?;
-                // ignore ambient broadcasts in the listen window: a poll response
-                // is always a unicast, and returning early would let flush() drop it
-                if matches!(
-                    received.frame.header.destination,
-                    Some(Address::Short(_, ieee802154::mac::ShortAddress(d))) if d >= 0xfff8
-                ) {
-                    log::debug!("[MLME-POLL] skip broadcast in poll window");
-                    continue;
-                }
-                if let Some((len, lqi)) = copy_data_payload(received, buf) {
-                    log::debug!("[MLME-POLL] rx data len={len}");
-                    return Ok((len, lqi));
-                }
+
+        // retry the poll handshake (§7.5.6.3)
+        for _ in 0..POLL_DATA_RETRIES {
+            let (data_req, len) = self.data_request_frame(coord_address)?;
+            match self.transmit_acked(&data_req[..len]).await {
+                // no ack after retries: the parent may be busy; keep listening
+                Ok(()) | Err(MacError::NoAck) => {}
+                Err(e) => return Err(e),
             }
-        };
-        match embassy_futures::select::select(timeout, receive).await {
-            Either::First(_) => Err(MacError::NoData),
-            Either::Second(result) => result,
+            // arm RX for the indirect response (~2-3ms after the poll ack);
+            // start_receive is a no-op if already receiving
+            self.driver.start_receive();
+            if let Some((len, lqi)) = self.recv_data_response(timeout_us, buf).await? {
+                log::debug!("[MLME-POLL] rx data len={len}");
+                return Ok((len, lqi));
+            }
         }
+        Err(MacError::NoData)
     }
 
     async fn transmit_data(&mut self, dest: Address, payload: &[u8]) -> Result<(), MacError> {
@@ -596,7 +639,14 @@ impl EspMlmeInner<'_> {
         // bytes during transmission
         let total_len = hdr_len + payload_len + 2;
 
-        self.driver.transmit(&frame_buf[..total_len]).await?;
+        // retransmit unicasts per §7.5.6.4: a single CCA-busy or lost ack must
+        // not drop a ZDO/APS response — the coordinator treats the silence as
+        // an interview failure
+        if is_broadcast {
+            self.driver.transmit(&frame_buf[..total_len]).await?;
+        } else {
+            self.transmit_acked(&frame_buf[..total_len]).await?;
+        }
         log::debug!("[MLME] tx data, len={total_len}");
 
         Ok(())

--- a/zigbee-mac/src/mlme.rs
+++ b/zigbee-mac/src/mlme.rs
@@ -110,6 +110,12 @@ pub enum MacError {
     #[error("no acknowledgment received")]
     NoAck,
     #[cfg(feature = "esp32c6")]
+    #[error("transmit failed (no ack, channel busy or coex abort)")]
+    TxFailed,
+    #[cfg(feature = "esp32c6")]
+    #[error("transmit-done signal timed out")]
+    TxTimeout,
+    #[cfg(feature = "esp32c6")]
     #[error("radio error")]
     RadioError(#[from] esp_radio::ieee802154::Error),
 }

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -196,11 +196,8 @@ impl Apsme {
         self.process_nwk_data(nlme, nwk_data)
     }
 
-    /// Poll the parent once (MLME-POLL) and process the retrieved APS frame.
-    ///
-    /// The sleepy-end-device counterpart of [`Self::receive_aps_frame`]: a
-    /// device with rxOnWhenIdle = FALSE only receives unicast frames its
-    /// parent buffered by explicitly polling for them (§3.6.6).
+    /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved APS
+    /// frame — the sleepy-end-device counterpart of [`Self::receive_aps_frame`].
     pub(crate) async fn poll_aps_frame<'a, M: zigbee_mac::mlme::Mlme>(
         &self,
         nlme: &Nlme<M>,

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -197,7 +197,8 @@ impl Apsme {
     }
 
     /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved APS
-    /// frame — the sleepy-end-device counterpart of [`Self::receive_aps_frame`].
+    /// frame — the sleepy-end-device counterpart of
+    /// [`Self::receive_aps_frame`].
     pub(crate) async fn poll_aps_frame<'a, M: zigbee_mac::mlme::Mlme>(
         &self,
         nlme: &Nlme<M>,

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -190,9 +190,35 @@ impl Apsme {
     ) -> Result<Option<ApsdeSapIndication<'a>>, NetworkError> {
         // no application data: a NWK command frame (handled by the NWK layer) or
         // other non-data frame shared the receive path
-        let Some(mut nwk_data) = nlme.receive_nwk_frame(buf).await? else {
+        let Some(nwk_data) = nlme.receive_nwk_frame(buf).await? else {
             return Ok(None);
         };
+        self.process_nwk_data(nlme, nwk_data)
+    }
+
+    /// Poll the parent once (MLME-POLL) and process the retrieved APS frame.
+    ///
+    /// The sleepy-end-device counterpart of [`Self::receive_aps_frame`]: a
+    /// device with rxOnWhenIdle = FALSE only receives unicast frames its
+    /// parent buffered by explicitly polling for them (§3.6.6).
+    pub(crate) async fn poll_aps_frame<'a, M: zigbee_mac::mlme::Mlme>(
+        &self,
+        nlme: &Nlme<M>,
+        buf: &'a mut [u8],
+    ) -> Result<Option<ApsdeSapIndication<'a>>, NetworkError> {
+        let Some(nwk_data) = nlme.poll_nwk_frame(buf).await? else {
+            return Ok(None);
+        };
+        self.process_nwk_data(nlme, nwk_data)
+    }
+
+    /// Process one inbound NWK data frame into an APSDE-DATA.indication
+    /// (§2.2.4.1.3); APS command frames are handled internally (§4.4).
+    fn process_nwk_data<'a, M: zigbee_mac::mlme::Mlme>(
+        &self,
+        nlme: &Nlme<M>,
+        mut nwk_data: crate::nwk::frame::DataFrame<'a>,
+    ) -> Result<Option<ApsdeSapIndication<'a>>, NetworkError> {
         let src_short = nwk_data.header.source.0;
         let local_addr = nlme.nib().network_address();
         let aps_bytes = nwk_data.payload;
@@ -338,7 +364,7 @@ impl Apsme {
         let payload_len = payload.len().min(buf.len() - hdr_len);
         buf[hdr_len..hdr_len + payload_len].copy_from_slice(&payload[..payload_len]);
 
-        nlme.broadcast_data(nwk_broadcast, false, &buf[..hdr_len + payload_len])
+        nlme.broadcast_data(nwk_broadcast, true, &buf[..hdr_len + payload_len])
             .await
     }
 }

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -175,7 +175,8 @@ impl Apsme {
         Ok(command)
     }
 
-    /// Passively receive and process one inbound APS frame.
+    /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved APS
+    /// frame.
     ///
     /// An APS **data** frame is surfaced as an APSDE-DATA.indication
     /// (§2.2.4.1.3); an APS **command** frame is processed internally (§4.4)
@@ -183,22 +184,6 @@ impl Apsme {
     /// coordinator is NWK-encrypted only, so only APS-unsecured data frames
     /// produce an indication. `src_address` carries the NWK source so the
     /// caller can address a response back to the requester.
-    pub(crate) async fn receive_aps_frame<'a, M: zigbee_mac::mlme::Mlme>(
-        &self,
-        nlme: &Nlme<M>,
-        buf: &'a mut [u8],
-    ) -> Result<Option<ApsdeSapIndication<'a>>, NetworkError> {
-        // no application data: a NWK command frame (handled by the NWK layer) or
-        // other non-data frame shared the receive path
-        let Some(nwk_data) = nlme.receive_nwk_frame(buf).await? else {
-            return Ok(None);
-        };
-        self.process_nwk_data(nlme, nwk_data)
-    }
-
-    /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved APS
-    /// frame — the sleepy-end-device counterpart of
-    /// [`Self::receive_aps_frame`].
     pub(crate) async fn poll_aps_frame<'a, M: zigbee_mac::mlme::Mlme>(
         &self,
         nlme: &Nlme<M>,

--- a/zigbee/src/aps/frame/frame_control.rs
+++ b/zigbee/src/aps/frame/frame_control.rs
@@ -72,10 +72,12 @@ impl FrameControl {
     /// Whether the endpoint, cluster, and profile fields are present
     /// (§2.2.5.1).
     ///
-    /// True for data frames and for ack frames with ack_format set.
+    /// True for data frames and for data-frame acknowledgements. An ack
+    /// format sub-field of 1 marks an APS *command* frame acknowledgement,
+    /// which carries no addressing fields (§2.2.5.1.1.4).
     pub fn has_data_fields(&self) -> bool {
         matches!(self.frame_type(), FrameType::Data | FrameType::InterPan)
-            || (self.frame_type() == FrameType::Acknowledgement && self.ack_format_flag())
+            || (self.frame_type() == FrameType::Acknowledgement && !self.ack_format_flag())
     }
 
     /// Whether the destination endpoint field is present (§2.2.5.1.2).

--- a/zigbee/src/aps/frame/frame_control.rs
+++ b/zigbee/src/aps/frame/frame_control.rs
@@ -72,9 +72,8 @@ impl FrameControl {
     /// Whether the endpoint, cluster, and profile fields are present
     /// (§2.2.5.1).
     ///
-    /// True for data frames and for data-frame acknowledgements. An ack
-    /// format sub-field of 1 marks an APS *command* frame acknowledgement,
-    /// which carries no addressing fields (§2.2.5.1.1.4).
+    /// True for data frames and data-frame acks; an ack format sub-field of
+    /// 1 marks a command-frame ack without addressing fields (§2.2.5.1.1.4).
     pub fn has_data_fields(&self) -> bool {
         matches!(self.frame_type(), FrameType::Data | FrameType::InterPan)
             || (self.frame_type() == FrameType::Acknowledgement && !self.ack_format_flag())

--- a/zigbee/src/nwk/nib.rs
+++ b/zigbee/src/nwk/nib.rs
@@ -100,18 +100,18 @@ pub const MAX_PARENT_LINK_COST: u8 = 3;
 /// is typically in the range 0–255.
 pub fn link_cost_from_lqi(lqi: u8) -> u8 {
     match lqi {
-        // Excellent link
-        200..=255 => 1,
-        // Good link
-        150..=199 => 2,
-        // Acceptable
-        120..=149 => 3,
+        // Excellent link (≥ -55 dBm)
+        128..=255 => 1,
+        // Good link (≥ -65 dBm)
+        77..=127 => 2,
+        // Acceptable (≥ -75 dBm)
+        26..=76 => 3,
         // Marginal
-        90..=119 => 5,
+        11..=25 => 5,
         // Poor
-        50..=89 => 6,
+        1..=10 => 6,
         // Very poor
-        _ => 7,
+        0 => 7,
     }
 }
 

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -295,10 +295,9 @@ where
     /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved NWK
     /// frame, if any.
     ///
-    /// A sleepy end device (rxOnWhenIdle = FALSE) never receives unicast
-    /// frames passively: its parent buffers them for indirect transmission
-    /// and only delivers on a MAC data request. Returns `Ok(None)` when the
-    /// parent has nothing buffered or the frame carried no application data.
+    /// A sleepy end device only receives buffered unicasts by polling.
+    /// Returns `Ok(None)` when nothing was buffered or the frame carried no
+    /// application data.
     pub async fn poll_nwk_frame<'a>(
         &self,
         buf: &'a mut [u8],
@@ -676,11 +675,8 @@ where
     ) -> Result<(), NetworkError> {
         let mut buf = [0u8; 256];
         let total_len = self.build_nwk_data_frame(destination, secure, payload, &mut buf)?;
-        // §3.6.5: an end device with rxOnWhenIdle = FALSE does not transmit
-        // broadcasts itself — it unicasts the frame to its parent, which
-        // relays it into the network on its behalf. (A MAC destination equal
-        // to the NWK broadcast address would pass no receiver's address
-        // filter: only the own short address and 0xFFFF are accepted.)
+        // §3.6.5: a sleepy end device unicasts broadcasts to its parent,
+        // which relays them into the network on its behalf
         let mac_dest = self.parent_address()?;
         self.mac.transmit_data(mac_dest, &buf[..total_len]).await?;
         Ok(())

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -289,9 +289,36 @@ where
         buf: &'a mut [u8],
     ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
         let (len, _lqi) = self.mac.receive(buf).await?;
+        self.process_received_nwk_frame(&mut buf[..len])
+    }
 
+    /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved NWK
+    /// frame, if any.
+    ///
+    /// A sleepy end device (rxOnWhenIdle = FALSE) never receives unicast
+    /// frames passively: its parent buffers them for indirect transmission
+    /// and only delivers on a MAC data request. Returns `Ok(None)` when the
+    /// parent has nothing buffered or the frame carried no application data.
+    pub async fn poll_nwk_frame<'a>(
+        &self,
+        buf: &'a mut [u8],
+    ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
+        let coord_addr = self.parent_address()?;
+        let (len, _lqi) = match self.mac.poll_data(coord_addr, buf).await {
+            Ok(result) => result,
+            Err(MacError::NoData) => return Ok(None),
+            Err(e) => return Err(e.into()),
+        };
+        self.process_received_nwk_frame(&mut buf[..len])
+    }
+
+    /// Decrypt one inbound NWK frame and hand NWK commands to the NWK layer.
+    fn process_received_nwk_frame<'a>(
+        &self,
+        frame_buf: &'a mut [u8],
+    ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
         let cx = SecurityContext::get();
-        let nwk_frame = cx.decrypt_nwk_frame_in_place(&mut buf[..len])?;
+        let nwk_frame = cx.decrypt_nwk_frame_in_place(frame_buf)?;
 
         match nwk_frame {
             NwkFrame::Data(data_frame) => Ok(Some(data_frame)),
@@ -647,10 +674,14 @@ where
         secure: bool,
         payload: &[u8],
     ) -> Result<(), NetworkError> {
-        let panid = self.nib().panid();
         let mut buf = [0u8; 256];
         let total_len = self.build_nwk_data_frame(destination, secure, payload, &mut buf)?;
-        let mac_dest = Address::Short(PanId(panid), MacShortAddress(destination.0));
+        // §3.6.5: an end device with rxOnWhenIdle = FALSE does not transmit
+        // broadcasts itself — it unicasts the frame to its parent, which
+        // relays it into the network on its behalf. (A MAC destination equal
+        // to the NWK broadcast address would pass no receiver's address
+        // filter: only the own short address and 0xFFFF are accepted.)
+        let mac_dest = self.parent_address()?;
         self.mac.transmit_data(mac_dest, &buf[..total_len]).await?;
         Ok(())
     }

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -260,36 +260,16 @@ where
         Ok(addr)
     }
 
-    async fn poll_nwk_data_request<'a>(
-        &self,
-        buf: &'a mut [u8],
-    ) -> Result<NwkDataFrame<'a>, NetworkError> {
-        let coord_addr = self.parent_address()?;
-        let (len, _lqi) = self.mac.poll_data(coord_addr, buf).await?;
-
-        let cx = SecurityContext::get();
-        let nwk_frame = cx.decrypt_nwk_frame_in_place(&mut buf[..len])?;
-
-        let NwkFrame::Data(data_frame) = nwk_frame else {
-            return Err(NetworkError::InvalidFrame);
-        };
-
-        Ok(data_frame)
-    }
-
-    /// Passively receive and process one inbound NWK frame (no MLME-POLL).
+    /// Issue one MLME-POLL to the parent (§3.6.6).
     ///
-    /// Awaits the next inbound MAC data frame via [`Mlme::receive`], strips and
-    /// decrypts the NWK header. A NWK data frame is returned to the caller; a
-    /// NWK command frame is processed internally and yields `Ok(None)` (no
-    /// application data). Intended for the steady-state receive loop after
-    /// joining.
-    pub async fn receive_nwk_frame<'a>(
-        &self,
-        buf: &'a mut [u8],
-    ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
-        let (len, _lqi) = self.mac.receive(buf).await?;
-        self.process_received_nwk_frame(&mut buf[..len])
+    /// Returns the raw MAC payload length, or `None` when nothing was buffered.
+    async fn poll_parent(&self, buf: &mut [u8]) -> Result<Option<usize>, NetworkError> {
+        let coord_addr = self.parent_address()?;
+        match self.mac.poll_data(coord_addr, buf).await {
+            Ok((len, _lqi)) => Ok(Some(len)),
+            Err(MacError::NoData) => Ok(None),
+            Err(e) => Err(e.into()),
+        }
     }
 
     /// Poll the parent once (MLME-POLL, §3.6.6) and process the retrieved NWK
@@ -302,11 +282,8 @@ where
         &self,
         buf: &'a mut [u8],
     ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
-        let coord_addr = self.parent_address()?;
-        let (len, _lqi) = match self.mac.poll_data(coord_addr, buf).await {
-            Ok(result) => result,
-            Err(MacError::NoData) => return Ok(None),
-            Err(e) => return Err(e.into()),
+        let Some(len) = self.poll_parent(buf).await? else {
+            return Ok(None);
         };
         self.process_received_nwk_frame(&mut buf[..len])
     }
@@ -640,19 +617,15 @@ where
             // need to get rid of the 'a lifetime in the loop
             // &mut buf is still guaranteed within 'a
             let buf = unsafe { slice::from_raw_parts_mut(buf.as_mut_ptr(), buf.len()) };
-            match self.poll_nwk_data_request(buf).await {
-                Ok(data_frame) => {
+            match self.poll_nwk_frame(buf).await {
+                Ok(Some(data_frame)) => {
                     return Ok(data_frame);
                 }
-                // keep polling: NoData (nothing buffered), or ambient traffic the
-                // pre-key joiner cannot decode (SecurityError/ParseError/InvalidFrame).
-                // the NWK-unsecured transport-key (§4.6.3.7.2) stays buffered for a later poll
-                Err(
-                    NetworkError::MacError(MacError::NoData)
-                    | NetworkError::SecurityError(_)
-                    | NetworkError::ParseError
-                    | NetworkError::InvalidFrame,
-                ) => (),
+                // keep polling: nothing buffered, a NWK command frame, or ambient
+                // traffic the pre-key joiner cannot decode (SecurityError/ParseError).
+                // the NWK-unsecured transport-key (§4.6.3.7.2) stays buffered for a
+                // later poll
+                Ok(None) | Err(NetworkError::SecurityError(_) | NetworkError::ParseError) => (),
                 Err(e) => return Err(e),
             }
         }

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -330,7 +330,7 @@ impl<M: Mlme> ZigbeeDevice<M> {
         let mut rx = [0u8; 256];
         let mut out = [0u8; 128];
 
-        let indication = match self.apsme.receive_aps_frame(&self.nlme, &mut rx).await {
+        let indication = match self.apsme.poll_aps_frame(&self.nlme, &mut rx).await {
             Ok(indication) => indication,
             // ambient traffic we cannot decode (foreign or pre-key frames caught
             // in the receive window) — normal, not a fault.
@@ -448,11 +448,16 @@ impl<M: Mlme> ZigbeeDevice<M> {
         Some(result)
     }
 
-    /// Run the receive/dispatch loop forever (the steady-state RX task).
+    /// Run the poll/dispatch loop forever (the steady-state RX task).
     ///
-    /// Each iteration passively receives one frame and answers it. Intended to
-    /// be spawned as a dedicated task with `&'static self`; the application's
-    /// transmit path may call other `&self` methods concurrently.
+    /// Each iteration issues one MLME-POLL to the parent and answers the
+    /// retrieved frame. Intended to be spawned as a dedicated task with
+    /// `&'static self`; the application's transmit path may call other
+    /// `&self` methods concurrently.
+    ///
+    /// Back-to-back iterations poll the parent as fast as it answers "no
+    /// data" — prefer calling [`Self::poll_and_dispatch`] from your own loop
+    /// with a sleep in between to pace the data requests.
     pub async fn rx_loop(
         &self,
         cfg: &descriptor::DeviceDescriptorConfig<'_>,

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -450,14 +450,9 @@ impl<M: Mlme> ZigbeeDevice<M> {
 
     /// Run the poll/dispatch loop forever (the steady-state RX task).
     ///
-    /// Each iteration issues one MLME-POLL to the parent and answers the
-    /// retrieved frame. Intended to be spawned as a dedicated task with
-    /// `&'static self`; the application's transmit path may call other
-    /// `&self` methods concurrently.
-    ///
-    /// Back-to-back iterations poll the parent as fast as it answers "no
-    /// data" — prefer calling [`Self::poll_and_dispatch`] from your own loop
-    /// with a sleep in between to pace the data requests.
+    /// Polls the parent back-to-back — prefer calling
+    /// [`Self::poll_and_dispatch`] from your own loop with a sleep in
+    /// between to pace the data requests.
     pub async fn rx_loop(
         &self,
         cfg: &descriptor::DeviceDescriptorConfig<'_>,


### PR DESCRIPTION
<img width="1029" height="587" alt="Screenshot 2026-07-02 at 11 48 52" src="https://github.com/user-attachments/assets/ead47e95-4749-4072-b9dd-85d58be4b892" />
<img width="325" height="408" alt="Screenshot 2026-07-02 at 11 48 43" src="https://github.com/user-attachments/assets/6f31bd1e-34d2-48c2-9384-e0516bab8245" />

Adjust the `Device_annce` in NWK and adapt the LQI->link-cost table for better compatibility.
Also get the `example/esp-sensor` working with Home-Assistant by supporting the device interview, which never received the unicasts passively when `rxOnWhenIdle = FALSE` is set. The MLME-Poll will now handle this