### PR TITLE
feat: Leave handling + Mgmt_Leave

### DIFF
--- a/zigbee/src/nwk/nib/mod.rs
+++ b/zigbee/src/nwk/nib/mod.rs
@@ -37,6 +37,16 @@ impl_byte! {
 
 pub const NWK_COORDINATOR_ADDRESS: u16 = 0x0000;
 
+/// Network address of a device that is not joined (§3.6.1.10.4).
+pub const NWK_UNASSIGNED_ADDRESS: u16 = 0xffff;
+
+/// Broadcast to all devices (§3.6.5, Table 3-68).
+pub const NWK_BROADCAST_ALL: u16 = 0xffff;
+
+/// Lowest reserved broadcast address; anything above is a broadcast (Table
+/// 3-68).
+pub const NWK_BROADCAST_ADDRESS_MIN: u16 = 0xfff8;
+
 /// Neighbor table relationship values (Table 3-63).
 pub mod relationship {
     /// The neighbor is the parent of this device.

--- a/zigbee/src/nwk/nlme/management.rs
+++ b/zigbee/src/nwk/nlme/management.rs
@@ -165,12 +165,46 @@ pub struct NlmeDirectJoinRequest {}
 /// 3.2.2.17 - NLME-DIRECT-JOIN.confirm
 pub struct NlmeDirectJoinConfirm {}
 
-/// 3.2.2.18 - NLME-LEAVE.request
-pub struct NlmeLeaveRequest {}
-/// 3.2.2.19 - NLME-LEAVE.indication
-pub struct NlmeLeaveIndication {}
-/// 3.2.2.20 - NLME-LEAVE.confirm
-pub struct NlmeLeaveConfirm {}
+/// 3.2.2.18 - NLME-LEAVE.request (Table 3-26).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NlmeLeaveRequest {
+    /// IEEE address of the device to remove, or `None` for this device to
+    /// remove itself.
+    pub device_address: Option<IeeeAddress>,
+    /// Also ask the leaving device to remove its own children.
+    pub remove_children: bool,
+    /// Ask the leaving device to rejoin the network afterwards.
+    pub rejoin: bool,
+}
+/// 3.2.2.19 - NLME-LEAVE.indication (Table 3-27).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NlmeLeaveIndication {
+    /// IEEE address of the device that left, or `None` if this device was
+    /// removed by its parent.
+    pub device_address: Option<IeeeAddress>,
+    pub rejoin: bool,
+}
+/// 3.2.2.20 - NLME-LEAVE.confirm (Table 3-28).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NlmeLeaveConfirm {
+    pub status: NlmeLeaveStatus,
+    /// Echoes the request's `device_address`, or `None` for a self-leave.
+    pub device_address: Option<IeeeAddress>,
+}
+
+/// Status codes for NLME-LEAVE.confirm and Mgmt_Leave_rsp (Table 3-28).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NlmeLeaveStatus {
+    Success,
+    /// Not currently joined, or the request is otherwise malformed.
+    InvalidRequest,
+    /// `device_address` does not name a known end-device child.
+    UnknownDevice,
+    /// The MAC sub-layer failed to transmit the leave command frame.
+    MacError,
+    /// The requester is not allowed to remove this device (§3.6.1.10.3.1).
+    NotAuthorized,
+}
 
 /// 3.2.2.21 - NLME-RESET.request
 pub struct NlmeResetRequest {}

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -24,6 +24,10 @@ use management::NlmeEdScanRequest;
 use management::NlmeJoinConfirm;
 use management::NlmeJoinRequest;
 use management::NlmeJoinStatus;
+use management::NlmeLeaveConfirm;
+use management::NlmeLeaveIndication;
+use management::NlmeLeaveRequest;
+use management::NlmeLeaveStatus;
 use management::NlmeNetworkDiscoveryConfirm;
 use management::NlmeNetworkFormationConfirm;
 use management::NlmeNetworkFormationRequest;
@@ -53,6 +57,8 @@ use crate::nwk::frame::command::Command;
 use crate::nwk::frame::command::end_device_timeout_request;
 use crate::nwk::frame::command::end_device_timeout_request::EndDeviceTimeoutRequest;
 use crate::nwk::frame::command::end_device_timeout_response::EndDeviceTimeoutResponse;
+use crate::nwk::frame::command::leave::CommandOptions as LeaveCommandOptions;
+use crate::nwk::frame::command::leave::Leave;
 use crate::nwk::frame::command::rejoin_request;
 use crate::nwk::frame::command::rejoin_request::RejoinRequest;
 use crate::nwk::frame::command::rejoin_response::RejoinResponse;
@@ -64,7 +70,10 @@ use crate::nwk::nib;
 use crate::nwk::nib::CapabilityInformation;
 use crate::nwk::nib::DeviceType;
 use crate::nwk::nib::MAX_PARENT_LINK_COST;
+use crate::nwk::nib::NWK_BROADCAST_ADDRESS_MIN;
+use crate::nwk::nib::NWK_BROADCAST_ALL;
 use crate::nwk::nib::NWK_COORDINATOR_ADDRESS;
+use crate::nwk::nib::NWK_UNASSIGNED_ADDRESS;
 use crate::nwk::nib::Nib;
 use crate::nwk::nib::NwkNeighbor;
 use crate::nwk::nib::link_cost_from_lqi;
@@ -116,6 +125,9 @@ pub struct Nlme<M> {
     // Rejoin Response (§3.4.7) handed from the receive path to the rejoin
     // procedure waiting for it
     rejoin_response: Signal<RejoinResponse>,
+    // NLME-LEAVE.indication (§3.2.2.19) raised by the receive path for the
+    // higher layer, which decides whether to re-commission or rejoin
+    leave_indication: Signal<NlmeLeaveIndication>,
 }
 
 impl<M> Nlme<M>
@@ -135,7 +147,22 @@ where
             nwk_seq: AtomicU8::new(0),
             pending_timeout_request: AtomicU8::new(NO_PENDING_TIMEOUT),
             rejoin_response: Signal::new(),
+            leave_indication: Signal::new(),
         }
+    }
+
+    /// 3.2.2.19 - take a pending NLME-LEAVE.indication, if any.
+    ///
+    /// Reports that this device was removed from the network (device address
+    /// `None`), or that a neighbor left it. The indication stays pending until
+    /// taken.
+    pub fn take_leave_indication(&self) -> Option<NlmeLeaveIndication> {
+        self.leave_indication.try_take()
+    }
+
+    /// 3.2.2.19 - wait for the next NLME-LEAVE.indication.
+    pub async fn wait_leave_indication(&self) -> NlmeLeaveIndication {
+        self.leave_indication.wait().await
     }
 
     fn next_nwk_seq(&self) -> u8 {
@@ -457,7 +484,7 @@ where
         let Some(len) = self.poll_parent(buf).await? else {
             return Ok(None);
         };
-        self.process_received_nwk_frame(&mut buf[..len])
+        self.process_received_nwk_frame(&mut buf[..len]).await
     }
 
     /// Passively wait for the next inbound NWK frame and process it.
@@ -470,11 +497,11 @@ where
         buf: &'a mut [u8],
     ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
         let (len, _lqi) = self.mac.receive(buf).await?;
-        self.process_received_nwk_frame(&mut buf[..len])
+        self.process_received_nwk_frame(&mut buf[..len]).await
     }
 
     /// Decrypt one inbound NWK frame and hand NWK commands to the NWK layer.
-    fn process_received_nwk_frame<'a>(
+    async fn process_received_nwk_frame<'a>(
         &self,
         frame_buf: &'a mut [u8],
     ) -> Result<Option<NwkDataFrame<'a>>, NetworkError> {
@@ -491,7 +518,8 @@ where
             // "no data" so the APS/ZDO caller skips this frame.
             NwkFrame::NwkCommand(command_frame) => {
                 self.learn_neighbor_ieee_address(&command_frame.header);
-                self.handle_nwk_command(command_frame.command);
+                self.handle_nwk_command(&command_frame.header, command_frame.command)
+                    .await;
                 Ok(None)
             }
             _ => Ok(None),
@@ -504,7 +532,7 @@ where
     /// handler can be filled in. Most are not yet acted upon — they are logged
     /// and ignored. Returning unit keeps the caller's receive loop simple; add
     /// a result type here if a handler needs to surface failures.
-    fn handle_nwk_command(&self, command: Command<'_>) {
+    async fn handle_nwk_command(&self, header: &NwkHeader<'_>, command: Command<'_>) {
         match command {
             // routing (§3.4.1–3.4.2): a sleepy end device routes via its parent,
             // so route discovery is currently a no-op.
@@ -515,8 +543,7 @@ where
             Command::NetworkStatus(_) => log::trace!("[NWK] network status (ignored)"),
             Command::NetworkReport(_) => log::trace!("[NWK] network report (ignored)"),
             Command::NetworkUpdate(_) => log::trace!("[NWK] network update (ignored)"),
-            // TODO: a Leave addressed to us should clear NIB state and re-commission.
-            Command::Leave(_) => log::trace!("[NWK] leave (ignored)"),
+            Command::Leave(leave) => self.handle_leave_command(header, &leave).await,
             // rejoin (§3.4.6–3.4.7): a request is parent-side only; a response
             // is handed to the rejoin procedure waiting for it, which may be
             // driven by another task than this receive path
@@ -569,6 +596,230 @@ where
             }
             Command::Reserved(id) => log::trace!("[NWK] reserved command {id:#04x} (ignored)"),
         }
+    }
+
+    /// Process an inbound Leave command frame (§3.6.1.10.3).
+    ///
+    /// TODO: a router receiving a notification from its parent with the remove
+    /// children sub-field set must rebroadcast the leave to its own children.
+    async fn handle_leave_command(&self, header: &NwkHeader<'_>, leave: &Leave) {
+        let options = leave.command_options;
+        let is_from_parent = self
+            .parent_short_address()
+            .is_ok_and(|parent| parent == header.source);
+
+        if !options.request() {
+            // notification: the sender left the network on its own initiative —
+            // it is no longer a neighbor regardless of the rejoin flag.
+            self.nib().update_neighbor_table(|table| {
+                table.retain(|n| n.network_address != header.source);
+            });
+
+            if is_from_parent {
+                // our parent has dropped us: we are no longer on the network,
+                // and the indication carries a NULL device address (§3.6.1.10.3)
+                self.nib().update_extended_panid(|value| *value = 0);
+                log::info!("[NWK] removed by parent (leave notification)");
+                self.leave_indication.signal(NlmeLeaveIndication {
+                    device_address: None,
+                    rejoin: options.rejoin(),
+                });
+            } else {
+                log::debug!(
+                    "[NWK] neighbor {:?} left the network (rejoin={})",
+                    header.source_ieee,
+                    options.rejoin()
+                );
+                self.leave_indication.signal(NlmeLeaveIndication {
+                    device_address: header.source_ieee,
+                    rejoin: options.rejoin(),
+                });
+            }
+            return;
+        }
+
+        // request == 1: someone is asking us to leave (§3.6.1.10.3.1)
+        if !self.accepts_leave_request(header.source, header.destination) {
+            return;
+        }
+
+        if let Err(e) = self
+            .leave_network(options.remove_children(), options.rejoin())
+            .await
+        {
+            log::warn!("[NWK] failed to announce leave: {e:?}");
+        }
+    }
+
+    /// Validate a leave request against §3.6.1.10.3.1, which governs both the
+    /// NWK Leave (request) command and the ZDO Mgmt_Leave_req.
+    ///
+    /// `source` is the network address of the sending device, `destination`
+    /// the address the request was addressed to.
+    pub fn accepts_leave_request(&self, source: ShortAddress, destination: ShortAddress) -> bool {
+        // step 1: the coordinator never leaves, and a broadcast request is
+        // dropped without further processing
+        if *self.nib().network_address() == NWK_COORDINATOR_ADDRESS
+            || destination.0 >= NWK_BROADCAST_ADDRESS_MIN
+        {
+            log::trace!("[NWK] leave request dropped (coordinator or broadcast destination)");
+            return false;
+        }
+
+        // step 2: a router honors any sender while nwkLeaveRequestAllowed is
+        // set, ignoring the neighbor relationship
+        if self.nib().capability_information().device_type() {
+            let allowed = *self.nib().leave_request_allowed();
+            if !allowed {
+                log::trace!("[NWK] leave request refused (nwkLeaveRequestAllowed is FALSE)");
+            }
+            return allowed;
+        }
+
+        // step 3: an end device is only removed by its parent
+        let is_from_parent = self
+            .parent_short_address()
+            .is_ok_and(|parent| parent == source);
+        if !is_from_parent {
+            log::trace!("[NWK] leave request refused (sender {source:?} is not our parent)");
+        }
+        is_from_parent
+    }
+
+    /// 3.2.2.18
+    ///
+    /// Only self-removal (`device_address` `None` or this device's own IEEE
+    /// address) is implemented: removing a child requires acting as its
+    /// parent, which this stack does not yet support.
+    pub async fn leave(&self, request: NlmeLeaveRequest) -> NlmeLeaveConfirm {
+        if *self.nib().network_address() == NWK_UNASSIGNED_ADDRESS {
+            return NlmeLeaveConfirm {
+                status: NlmeLeaveStatus::InvalidRequest,
+                device_address: request.device_address,
+            };
+        }
+
+        let is_self = request
+            .device_address
+            .is_none_or(|addr| addr == *self.nib().ieee_address());
+        if !is_self {
+            return NlmeLeaveConfirm {
+                status: NlmeLeaveStatus::UnknownDevice,
+                device_address: request.device_address,
+            };
+        }
+
+        let status = match self
+            .leave_network(request.remove_children, request.rejoin)
+            .await
+        {
+            Ok(()) => NlmeLeaveStatus::Success,
+            Err(_) => NlmeLeaveStatus::MacError,
+        };
+        NlmeLeaveConfirm {
+            status,
+            device_address: None,
+        }
+    }
+
+    /// §3.6.1.10.1 + §3.6.1.10.4: announce this device's own removal from the
+    /// network, then apply the local leave procedure.
+    ///
+    /// The local leave runs whether or not the announcement made it onto the
+    /// air; the transmit result only feeds the NLME-LEAVE.confirm status.
+    async fn leave_network(&self, remove_children: bool, rejoin: bool) -> Result<(), NetworkError> {
+        let result = self.announce_leave(remove_children, rejoin).await;
+        self.local_leave(rejoin);
+        result
+    }
+
+    /// §3.6.1.10.1: transmit this device's own leave command frame, with the
+    /// request sub-field set to 0 — a notification, never a request addressed
+    /// to someone else.
+    async fn announce_leave(
+        &self,
+        remove_children: bool,
+        rejoin: bool,
+    ) -> Result<(), NetworkError> {
+        let is_router_or_coordinator = self.nib().capability_information().device_type()
+            || *self.nib().network_address() == NWK_COORDINATOR_ADDRESS;
+
+        let mut buf = [0u8; 64];
+        if is_router_or_coordinator {
+            let command = Command::Leave(Leave {
+                command_options: LeaveCommandOptions(0)
+                    .set_remove_children(remove_children)
+                    .set_rejoin(rejoin),
+            });
+            let len = self.build_nwk_command_frame(
+                ShortAddress(NWK_BROADCAST_ALL),
+                command,
+                true,
+                &mut buf,
+            )?;
+            self.mac
+                .transmit_data(
+                    Address::Short(
+                        PanId(*self.nib().panid()),
+                        MacShortAddress(NWK_BROADCAST_ALL),
+                    ),
+                    &buf[..len],
+                )
+                .await?;
+            return Ok(());
+        }
+
+        // an end device unicasts to its parent and sends the remove children
+        // sub-field as 0; only the rejoin flag is carried over
+        let command = Command::Leave(Leave {
+            command_options: LeaveCommandOptions(0).set_rejoin(rejoin),
+        });
+        let len =
+            self.build_nwk_command_frame(self.parent_short_address()?, command, true, &mut buf)?;
+        let result = self
+            .mac
+            .transmit_data(self.parent_address()?, &buf[..len])
+            .await;
+        // §3.6.1.10.1: an end device clears the extended PAN id right after
+        // transmitting, ahead of the rest of the local leave process.
+        self.nib().update_extended_panid(|value| *value = 0);
+        result.map_err(Into::into)
+    }
+
+    /// §3.6.1.10.4: the local half of the leave procedure.
+    fn local_leave(&self, rejoin: bool) {
+        if rejoin {
+            // step 1: with Rejoin set the NIB is kept, so the remembered
+            // network is still there for a later NLME-JOIN.request with
+            // `RejoinNetwork::NwkRejoin`; driving that is the higher layer's
+            // call, which the NLME-LEAVE.indication/confirm hands it.
+            log::info!("[NWK] left the network, rejoin requested");
+            return;
+        }
+
+        self.clear_nib_on_leave();
+    }
+
+    /// §3.6.1.10.4 (Rejoin = FALSE): clear the NIB attributes describing
+    /// network membership, leaving the device unjoined.
+    fn clear_nib_on_leave(&self) {
+        let nib = self.nib();
+        nib.update_neighbor_table(|value| value.clear());
+        nib.update_route_table(|value| value.clear());
+        nib.update_manager_addr(|value| *value = 0x0000);
+        nib.update_update_id(|value| *value = 0x00);
+        nib.update_network_address(|value| *value = NWK_UNASSIGNED_ADDRESS);
+        nib.update_group_idtable(|value| value.clear());
+        nib.update_extended_panid(|value| *value = 0);
+        nib.update_route_record_table(|value| value.clear());
+        nib.update_is_concentrator(|value| *value = false);
+        nib.update_concentrator_radius(|value| *value = 0);
+        nib.update_security_material_set(|value| value.clear());
+        nib.update_active_key_seq_number(|value| *value = 0x00);
+        nib.update_address_map(|value| value.clear());
+        nib.update_panid(|value| *value = 0xffff);
+        nib.update_tx_total(|value| *value = 0);
+        nib.update_parent_information(|value| *value = 0x00);
     }
 
     /// 3.2.2.3
@@ -948,7 +1199,7 @@ where
                 return;
             }
             match self.poll_parent(&mut buf).await {
-                Ok(Some(len)) => match self.process_received_nwk_frame(&mut buf[..len]) {
+                Ok(Some(len)) => match self.process_received_nwk_frame(&mut buf[..len]).await {
                     Ok(Some(_)) => log::debug!("[NWK-REJOIN] polled data frame dropped"),
                     Ok(None) => (),
                     Err(e) => log::debug!("[NWK-REJOIN] polled frame not processed: {e:?}"),
@@ -1656,10 +1907,13 @@ mod tests {
         let (_guard, nlme) = make_nlme(MockMlme::new());
         seed_joined_nib(&nlme);
 
-        nlme.handle_nwk_command(Command::RejoinResponse(RejoinResponse {
-            network_address: ShortAddress(0x5678),
-            status: 0x00,
-        }));
+        block_on(nlme.handle_nwk_command(
+            &dummy_header(0x0000),
+            Command::RejoinResponse(RejoinResponse {
+                network_address: ShortAddress(0x5678),
+                status: 0x00,
+            }),
+        ));
 
         assert_eq!(*nlme.nib().network_address(), 0x5678);
         block_on(nlme.rejoin_response.wait());
@@ -1713,6 +1967,22 @@ mod tests {
     // -------------------------------------------------------------------
     // end device timeout tests (§3.6.10)
     // -------------------------------------------------------------------
+
+    /// A minimal NWK header for feeding `handle_nwk_command` in tests; the
+    /// source address is the only field most handlers inspect.
+    fn dummy_header(source: u16) -> NwkHeader<'static> {
+        NwkHeader {
+            frame_control: NwkFrameControl(0).set_frame_type(NwkFrameType::NwkCommand),
+            destination: ShortAddress(0x0000),
+            source: ShortAddress(source),
+            radius: 1,
+            sequence_number: 0,
+            destination_ieee: None,
+            source_ieee: None,
+            multicast_control: None,
+            source_route_subframe: None,
+        }
+    }
 
     /// Seed the global NIB with a joined-network state: parent neighbor,
     /// addresses, and NWK security material.
@@ -1803,11 +2073,12 @@ mod tests {
         let (_guard, nlme) = make_nlme(MockMlme::new());
         nlme.pending_timeout_request.store(0x03, Ordering::Relaxed);
 
-        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
-            EndDeviceTimeoutResponse {
+        block_on(nlme.handle_nwk_command(
+            &dummy_header(0x0000),
+            Command::EndDeviceTimeoutResponse(EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_SUCCESS,
                 parent_information: 0b011,
-            },
+            }),
         ));
 
         let nib = nlme.nib();
@@ -1825,11 +2096,12 @@ mod tests {
         let (_guard, nlme) = make_nlme(MockMlme::new());
         nlme.pending_timeout_request.store(0x03, Ordering::Relaxed);
 
-        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
-            EndDeviceTimeoutResponse {
+        block_on(nlme.handle_nwk_command(
+            &dummy_header(0x0000),
+            Command::EndDeviceTimeoutResponse(EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_INCORRECT_VALUE,
                 parent_information: 0b001,
-            },
+            }),
         ));
 
         let nib = nlme.nib();
@@ -1841,16 +2113,261 @@ mod tests {
     fn end_device_timeout_response_unsolicited_ignored() {
         let (_guard, nlme) = make_nlme(MockMlme::new());
 
-        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
-            EndDeviceTimeoutResponse {
+        block_on(nlme.handle_nwk_command(
+            &dummy_header(0x0000),
+            Command::EndDeviceTimeoutResponse(EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_SUCCESS,
                 parent_information: 0b001,
-            },
+            }),
         ));
 
         let nib = nlme.nib();
         assert_eq!(*nib.parent_information(), 0x00);
         assert_eq!(*nib.end_device_timeout(), NO_PENDING_TIMEOUT);
+    }
+
+    // -------------------------------------------------------------------
+    // leave tests (§3.2.2.18, §3.6.1.10)
+    // -------------------------------------------------------------------
+
+    #[test]
+    fn leave_not_joined_is_invalid() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+
+        let confirm = block_on(nlme.leave(NlmeLeaveRequest {
+            device_address: None,
+            remove_children: false,
+            rejoin: false,
+        }));
+        assert_eq!(confirm.status, NlmeLeaveStatus::InvalidRequest);
+    }
+
+    #[test]
+    fn leave_other_device_is_unknown() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.leave(NlmeLeaveRequest {
+            device_address: Some(IeeeAddress(0x1111_1111_1111_1111)),
+            remove_children: false,
+            rejoin: false,
+        }));
+        assert_eq!(confirm.status, NlmeLeaveStatus::UnknownDevice);
+    }
+
+    #[test]
+    fn leave_self_end_device_unicasts_to_parent_and_clears_nib() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .withf(|dest, payload| {
+                assert_eq!(
+                    *dest,
+                    Address::Short(PanId(0xAAAA), MacShortAddress(0x0000))
+                );
+                let mut buf = [0u8; 256];
+                buf[..payload.len()].copy_from_slice(payload);
+                let frame = SecurityContext::get()
+                    .decrypt_nwk_frame_in_place(&mut buf[..payload.len()])
+                    .unwrap();
+                let NwkFrame::NwkCommand(command_frame) = frame else {
+                    panic!("expected NWK command frame");
+                };
+                let Command::Leave(leave) = command_frame.command else {
+                    panic!("expected leave command");
+                };
+                assert!(!leave.command_options.request());
+                assert!(!leave.command_options.rejoin());
+                assert!(!leave.command_options.remove_children());
+                true
+            })
+            .returning(|_, _| Ok(()));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        // §3.6.1.10.1: an end device sends the remove children sub-field as 0
+        // even when the request asked for it
+        let confirm = block_on(nlme.leave(NlmeLeaveRequest {
+            device_address: None,
+            remove_children: true,
+            rejoin: false,
+        }));
+        assert_eq!(confirm.status, NlmeLeaveStatus::Success);
+        assert_eq!(confirm.device_address, None);
+
+        let nib = nlme.nib();
+        assert_eq!(*nib.network_address(), 0xffff);
+        assert_eq!(*nib.extended_panid(), 0);
+        assert!(nib.neighbor_table().is_empty());
+        assert!(nib.security_material_set().is_empty());
+    }
+
+    #[test]
+    fn leave_self_clears_nib_even_when_transmit_fails() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .returning(|_, _| Err(MacError::NoAck));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.leave(NlmeLeaveRequest {
+            device_address: None,
+            remove_children: false,
+            rejoin: false,
+        }));
+        // §3.6.1.10.1: the local leave runs regardless of the confirm status
+        assert_eq!(confirm.status, NlmeLeaveStatus::MacError);
+        assert_eq!(*nlme.nib().network_address(), NWK_UNASSIGNED_ADDRESS);
+        assert!(nlme.nib().security_material_set().is_empty());
+    }
+
+    #[test]
+    fn leave_request_to_broadcast_address_is_dropped() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let header = NwkHeader {
+            destination: ShortAddress(0xfffd),
+            ..dummy_header(0x0000)
+        };
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_request(true),
+        };
+        // no transmit_data expectation set: a call here would panic the mock
+        block_on(nlme.handle_nwk_command(&header, Command::Leave(leave)));
+
+        assert_eq!(*nlme.nib().network_address(), 0x1234);
+    }
+
+    #[test]
+    fn leave_notification_from_parent_raises_indication() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_rejoin(true),
+        };
+        block_on(nlme.handle_nwk_command(&dummy_header(0x0000), Command::Leave(leave)));
+
+        // §3.6.1.10.3: removed by the parent -> NULL device address
+        assert_eq!(
+            nlme.take_leave_indication(),
+            Some(NlmeLeaveIndication {
+                device_address: None,
+                rejoin: true,
+            })
+        );
+    }
+
+    #[test]
+    fn leave_self_with_rejoin_leaves_nib_untouched() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.leave(NlmeLeaveRequest {
+            device_address: None,
+            remove_children: false,
+            rejoin: true,
+        }));
+        assert_eq!(confirm.status, NlmeLeaveStatus::Success);
+
+        let nib = nlme.nib();
+        // rejoin requested: the NIB is left intact for the (not yet
+        // implemented) rejoin procedure, aside from the extended PAN id
+        // which §3.6.1.10.1 clears unconditionally for an end device.
+        assert_eq!(*nib.network_address(), 0x1234);
+        assert_eq!(*nib.extended_panid(), 0);
+        assert!(!nib.neighbor_table().is_empty());
+    }
+
+    #[test]
+    fn leave_notification_removes_only_the_notifying_neighbor() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+        nlme.nib().update_neighbor_table(|table| {
+            let _ = table.push(make_neighbor(0xAAAA, 0x5678, 0xBEEF, 200, 1));
+        });
+        assert_eq!(nlme.nib().neighbor_table().len(), 2);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0),
+        };
+        block_on(nlme.handle_nwk_command(&dummy_header(0x5678), Command::Leave(leave)));
+
+        let nib = nlme.nib();
+        assert_eq!(nib.neighbor_table().len(), 1);
+        assert_eq!(
+            nib.neighbor_table()[0].network_address,
+            ShortAddress(0x0000)
+        );
+        // not our parent -> we are still joined
+        assert_ne!(*nib.network_address(), 0xffff);
+    }
+
+    #[test]
+    fn leave_notification_from_parent_marks_device_removed() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0),
+        };
+        block_on(nlme.handle_nwk_command(&dummy_header(0x0000), Command::Leave(leave)));
+
+        let nib = nlme.nib();
+        assert_eq!(*nib.extended_panid(), 0);
+        assert!(nib.neighbor_table().is_empty());
+    }
+
+    #[test]
+    fn leave_request_from_parent_triggers_self_removal() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_request(true),
+        };
+        block_on(nlme.handle_nwk_command(&dummy_header(0x0000), Command::Leave(leave)));
+
+        assert_eq!(*nlme.nib().network_address(), 0xffff);
+    }
+
+    #[test]
+    fn leave_request_from_non_parent_is_ignored() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_request(true),
+        };
+        // no transmit_data expectation set: a call here would panic the mock
+        block_on(nlme.handle_nwk_command(&dummy_header(0x9999), Command::Leave(leave)));
+
+        assert_eq!(*nlme.nib().network_address(), 0x1234);
+    }
+
+    #[test]
+    fn leave_request_dropped_for_coordinator() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+        nlme.nib().update_network_address(|value| *value = 0x0000);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_request(true),
+        };
+        // no transmit_data expectation set: a call here would panic the mock
+        block_on(nlme.handle_nwk_command(&dummy_header(0x0000), Command::Leave(leave)));
+
+        assert_eq!(*nlme.nib().network_address(), 0x0000);
     }
 
     #[test]

--- a/zigbee/src/zdo/descriptor.rs
+++ b/zigbee/src/zdo/descriptor.rs
@@ -10,6 +10,7 @@ use byte::ctx;
 use zigbee_types::IeeeAddress;
 
 use crate::apl::descriptors::node_descriptor::LogicalType;
+use crate::nwk::nlme::management::NlmeLeaveStatus;
 
 // ZDP request cluster identifiers (§2.4.3).
 pub const NWK_ADDR_REQ: u16 = 0x0000;
@@ -19,6 +20,7 @@ pub const SIMPLE_DESC_REQ: u16 = 0x0004;
 pub const ACTIVE_EP_REQ: u16 = 0x0005;
 pub const BIND_REQ: u16 = 0x0021;
 pub const UNBIND_REQ: u16 = 0x0022;
+pub const MGMT_LEAVE_REQ: u16 = 0x0034;
 
 // ZDP response cluster identifiers (§2.4.4): request id | 0x8000.
 pub const NWK_ADDR_RSP: u16 = 0x8000;
@@ -28,13 +30,27 @@ pub const SIMPLE_DESC_RSP: u16 = 0x8004;
 pub const ACTIVE_EP_RSP: u16 = 0x8005;
 pub const BIND_RSP: u16 = 0x8021;
 pub const UNBIND_RSP: u16 = 0x8022;
+pub const MGMT_LEAVE_RSP: u16 = 0x8034;
 
 /// ZDP status: SUCCESS (§2.4.5).
 const STATUS_SUCCESS: u8 = 0x00;
+/// ZDP status: the supplied request type was invalid.
+const STATUS_INV_REQUESTTYPE: u8 = 0x80;
+/// ZDP status: the requested device does not exist.
+const STATUS_DEVICE_NOT_FOUND: u8 = 0x81;
 /// ZDP status: supplied endpoint was 0x00 or 0xff.
 const STATUS_INVALID_EP: u8 = 0x82;
 /// ZDP status: requested endpoint is not described by a simple descriptor.
 const STATUS_NOT_ACTIVE: u8 = 0x83;
+/// ZDP status: the device is not in the proper state for the operation.
+const STATUS_NOT_PERMITTED: u8 = 0x8b;
+/// ZDP status: the command was rejected due to security restrictions.
+const STATUS_NOT_AUTHORIZED: u8 = 0x8d;
+
+/// Mgmt_Leave_req options: Remove Children (§2.4.3.3.5).
+const MGMT_LEAVE_REMOVE_CHILDREN: u8 = 0b0100_0000;
+/// Mgmt_Leave_req options: Rejoin (§2.4.3.3.5).
+const MGMT_LEAVE_REJOIN: u8 = 0b1000_0000;
 
 const NODE_DESCRIPTOR_SIZE: usize = 13;
 
@@ -241,6 +257,59 @@ pub fn bind_rsp(seq: u8, src_endpoint: u8, out: &mut [u8]) -> Result<usize, byte
     Ok(*offset)
 }
 
+/// A parsed Mgmt_Leave_req (§2.4.3.3.5).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MgmtLeaveReq {
+    /// ZDP transaction sequence number to echo in the response.
+    pub seq: u8,
+    /// Device to remove; `None` for the NULL address, which targets the
+    /// recipient itself.
+    pub device_address: Option<IeeeAddress>,
+    pub remove_children: bool,
+    pub rejoin: bool,
+}
+
+/// Parse a Mgmt_Leave_req payload (§2.4.3.3.5).
+///
+/// Returns `None` if the payload is too short.
+pub fn parse_mgmt_leave_req(asdu: &[u8]) -> Option<MgmtLeaveReq> {
+    let seq = *asdu.first()?;
+    let addr_bytes: [u8; 8] = asdu.get(1..9)?.try_into().ok()?;
+    let device_address = match u64::from_le_bytes(addr_bytes) {
+        0 => None,
+        addr => Some(IeeeAddress(addr)),
+    };
+    let options = *asdu.get(9)?;
+    Some(MgmtLeaveReq {
+        seq,
+        device_address,
+        remove_children: options & MGMT_LEAVE_REMOVE_CHILDREN != 0,
+        rejoin: options & MGMT_LEAVE_REJOIN != 0,
+    })
+}
+
+/// Map an NLME-LEAVE.confirm status onto the ZDP status enumeration (§2.4.5).
+///
+/// The Mgmt_Leave_rsp Status field carries NOT_SUPPORTED, NOT_AUTHORIZED or
+/// any status code returned by NLME-LEAVE.confirm (§2.4.4.4.5).
+pub fn leave_status(status: NlmeLeaveStatus) -> u8 {
+    match status {
+        NlmeLeaveStatus::Success => STATUS_SUCCESS,
+        NlmeLeaveStatus::InvalidRequest => STATUS_INV_REQUESTTYPE,
+        NlmeLeaveStatus::UnknownDevice => STATUS_DEVICE_NOT_FOUND,
+        NlmeLeaveStatus::MacError => STATUS_NOT_PERMITTED,
+        NlmeLeaveStatus::NotAuthorized => STATUS_NOT_AUTHORIZED,
+    }
+}
+
+/// Build a Mgmt_Leave_rsp payload (§2.4.4.4.5): seq, status.
+pub fn mgmt_leave_rsp(seq: u8, status: u8, out: &mut [u8]) -> Result<usize, byte::Error> {
+    let offset = &mut 0;
+    out.write_with(offset, seq, ctx::LE)?;
+    out.write_with(offset, status, ctx::LE)?;
+    Ok(*offset)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -356,5 +425,52 @@ mod tests {
                 0x34, 0x12, // NWK addr (LE)
             ]
         );
+    }
+
+    #[test]
+    fn parse_mgmt_leave_req_self_null_address() {
+        let asdu = [
+            0x09, // seq
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,
+            0x00,        // NULL device address
+            0b1100_0000, // remove children + rejoin
+        ];
+        let req = parse_mgmt_leave_req(&asdu).unwrap();
+        assert_eq!(req.seq, 0x09);
+        assert_eq!(req.device_address, None);
+        assert!(req.remove_children);
+        assert!(req.rejoin);
+    }
+
+    #[test]
+    fn parse_mgmt_leave_req_targets_device() {
+        let asdu = [
+            0x0a, // seq
+            0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00, // IEEE addr (LE)
+            0x00, // no flags
+        ];
+        let req = parse_mgmt_leave_req(&asdu).unwrap();
+        assert_eq!(req.seq, 0x0a);
+        assert_eq!(req.device_address, Some(IeeeAddress(0x0011_2233_4455_6677)));
+        assert!(!req.remove_children);
+        assert!(!req.rejoin);
+    }
+
+    #[test]
+    fn parse_mgmt_leave_req_too_short() {
+        assert!(parse_mgmt_leave_req(&[0x01, 0x02]).is_none());
+    }
+
+    #[test]
+    fn mgmt_leave_rsp_layout() {
+        let mut out = [0u8; 4];
+        let n = mgmt_leave_rsp(0x09, 0x00, &mut out).unwrap();
+        assert_eq!(&out[..n], &[0x09, 0x00]);
     }
 }

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -31,6 +31,8 @@ use crate::nwk::nib;
 use crate::nwk::nib::NetworkSecurityMaterialDescriptor;
 use crate::nwk::nlme::NetworkError;
 use crate::nwk::nlme::Nlme;
+use crate::nwk::nlme::management::NlmeLeaveRequest;
+use crate::nwk::nlme::management::NlmeLeaveStatus;
 use crate::security::SecurityContext;
 
 /// Number of MAC poll attempts when waiting for the Trust Center to deliver the
@@ -357,6 +359,26 @@ impl<M: Mlme> ZigbeeDevice<M> {
         self.joined.wait_set().await;
     }
 
+    /// Close the receive loop's join gate when the NWK layer reports that this
+    /// device was removed from the network (NLME-LEAVE.indication with a NULL
+    /// device address, §3.2.2.19).
+    ///
+    /// The loop then parks until the higher layer has re-commissioned or
+    /// rejoined, instead of polling a parent that dropped this device.
+    fn close_gate_on_leave_indication(&self) {
+        let Some(indication) = self.nlme.take_leave_indication() else {
+            return;
+        };
+        if indication.device_address.is_some() {
+            return;
+        }
+        log::info!(
+            "[ZDO] removed from the network (rejoin={})",
+            indication.rejoin
+        );
+        self.joined.reset();
+    }
+
     /// Arm the TC link key exchange (BDB §10.2.5): key-transport commands
     /// are honored and stale progress events are cleared. Disarm with
     /// [`Self::end_tc_link_key_exchange`] when the exchange concludes.
@@ -437,6 +459,10 @@ impl<M: Mlme> ZigbeeDevice<M> {
 
         let mut out = [0u8; 128];
 
+        // a NWK Leave command consumed by the NWK layer surfaces here as an
+        // NLME-LEAVE.indication rather than as a dispatchable frame
+        self.close_gate_on_leave_indication();
+
         // non-dispatchable frame (NWK command handled by the NWK layer; an APS
         // command is handled at its arrival point): wait for the next frame
         let Some(indication) = indication else {
@@ -454,8 +480,30 @@ impl<M: Mlme> ZigbeeDevice<M> {
             "[ZDO] rx profile={profile:#06x} cluster={cluster:#06x} from {src:#06x} ep {src_endpoint}->{dst_endpoint}"
         );
 
+        // deferred until after the response below has actually gone out: the
+        // leave procedure clears the NWK security material this reply is
+        // encrypted with, so executing it first would leave the reply
+        // unsendable.
+        let mut leave_after_reply = None;
+
         // (response cluster, profile, dst endpoint, src endpoint, length)
-        let response = if profile == ZDP_PROFILE_ID {
+        let response = if profile == ZDP_PROFILE_ID && cluster == descriptor::MGMT_LEAVE_REQ {
+            let destination = match indication.dst_address {
+                Address::Network(dst) => ShortAddress(dst),
+                _ => ShortAddress(*self.nlme.nib().network_address()),
+            };
+            self.build_mgmt_leave_rsp(indication.asdu, ShortAddress(src), destination, &mut out)
+                .map(|(len, request)| {
+                    leave_after_reply = request;
+                    (
+                        descriptor::MGMT_LEAVE_RSP,
+                        ZDP_PROFILE_ID,
+                        ZDO_ENDPOINT,
+                        ZDO_ENDPOINT,
+                        len,
+                    )
+                })
+        } else if profile == ZDP_PROFILE_ID {
             self.build_zdp_response(cluster, indication.asdu, cfg, &mut out)
                 .map(|(rsp_cluster, len)| {
                     (rsp_cluster, ZDP_PROFILE_ID, ZDO_ENDPOINT, ZDO_ENDPOINT, len)
@@ -490,7 +538,59 @@ impl<M: Mlme> ZigbeeDevice<M> {
         } else {
             log::trace!("[ZDO] no response for cluster {cluster:#06x}");
         }
+
+        if let Some(request) = leave_after_reply {
+            let confirm = self.nlme.leave(request).await;
+            log::info!(
+                "[ZDO] leaving network after Mgmt_Leave_req: {:?}",
+                confirm.status
+            );
+            // a self-leave yields a confirm, not an indication (§3.2.2.18), so
+            // close the gate here
+            self.joined.reset();
+        }
         Ok(())
+    }
+
+    /// Build a Mgmt_Leave_rsp payload (§2.4.4.4.5), returning its length and
+    /// the NLME-LEAVE.request the caller must issue once the response has been
+    /// sent.
+    ///
+    /// The request is validated as a leave request per §3.6.1.10.3.1, which
+    /// governs the Mgmt_Leave_req just as it does the NWK Leave command — an
+    /// end device is only removed by its parent. Only a request naming this
+    /// device (or the NULL address) is honored; removing a child requires
+    /// acting as its parent, which this stack does not yet support.
+    fn build_mgmt_leave_rsp(
+        &self,
+        asdu: &[u8],
+        source: ShortAddress,
+        destination: ShortAddress,
+        out: &mut [u8],
+    ) -> Option<(usize, Option<NlmeLeaveRequest>)> {
+        let request = descriptor::parse_mgmt_leave_req(asdu)?;
+
+        let own_ieee = *self.nlme.nib().ieee_address();
+        let is_self = request.device_address.is_none_or(|addr| addr == own_ieee);
+
+        let (status, leave) = if !is_self {
+            (NlmeLeaveStatus::UnknownDevice, None)
+        } else if !self.nlme.accepts_leave_request(source, destination) {
+            (NlmeLeaveStatus::NotAuthorized, None)
+        } else {
+            (
+                NlmeLeaveStatus::Success,
+                Some(NlmeLeaveRequest {
+                    device_address: None,
+                    remove_children: request.remove_children,
+                    rejoin: request.rejoin,
+                }),
+            )
+        };
+
+        let len =
+            descriptor::mgmt_leave_rsp(request.seq, descriptor::leave_status(status), out).ok()?;
+        Some((len, leave))
     }
 
     /// Build the ZDP `*_rsp` payload for a discovery request, echoing the
@@ -557,6 +657,9 @@ impl<M: Mlme> ZigbeeDevice<M> {
     /// end device polls the parent for buffered unicasts every
     /// `poll_interval_ms` — keep it below the parent's indirect-transaction
     /// persistence time (~7.68 s).
+    ///
+    /// A leave takes the device off the network and parks the loop until it
+    /// has been re-commissioned.
     pub async fn rx_loop(
         &self,
         cfg: &descriptor::DeviceDescriptorConfig<'_>,
@@ -577,12 +680,16 @@ impl<M: Mlme> ZigbeeDevice<M> {
             .receiver_on_when_idle()
         {
             loop {
+                // dispatching a leave closes the gate again, parking the loop
+                // until the higher layer has re-commissioned
+                self.wait_until_joined().await;
                 if let Err(e) = self.receive_and_dispatch(cfg, handler).await {
                     log::debug!("[ZDO] rx dispatch error: {e:?}");
                 }
             }
         }
         loop {
+            self.wait_until_joined().await;
             if let Err(e) = self.poll_and_dispatch(cfg, handler).await {
                 log::debug!("[ZDO] rx dispatch error: {e:?}");
             }


### PR DESCRIPTION
Device was connected to my test network and I went out of range on purpose to trigger the LEAVE.
As expected `report_failures >= MAX_REPORT_FAILURES` (4) triggers `forget_network()` + `flush` + `software_reset()`

```
Report failed: NoAck
Report failed: NoAck
Report failed: NoAck
Report failed: NoAck
Parent unreachable, forgetting network and rebooting
ESP-ROM:esp32c6-20220919
Build:Sep 19 2022
rst:0x3 (LP_SW_HPSYS),boot:0xc (SPI_FAST_FLASH_BOOT)
Saved PC:0x4001974a
SPIWP:0xee
mode:DIO, clock div:2
load:0x40875730,len:0x175c
load:0x4086b910,len:0xec8
load:0x4086e610,len:0x31c4
entry 0x4086b91a
I (22) boot: ESP-IDF v5.5.1-838-gd66ebb86d2e 2nd stage bootloader
I (23) boot: compile time Nov 27 2025 09:46:10
I (24) boot: chip revision: v0.1
I (24) boot: efuse block revision: v0.3
I (28) boot.esp32c6: SPI Speed      : 80MHz
I (31) boot.esp32c6: SPI Mode       : DIO
I (35) boot.esp32c6: SPI Flash Size : 4MB
I (39) boot: Enabling RNG early entropy source...
I (43) boot: Partition Table:
I (46) boot: ## Label            Usage          Type ST Offset   Length
I (52) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (59) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (65) boot:  2 factory          factory app      00 00 00010000 003f0000
I (72) boot: End of partition table
I (75) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=0d6f8h ( 55032) map
I (93) esp_image: segment 1: paddr=0001d720 vaddr=40800000 size=028f8h ( 10488) load
I (96) esp_image: segment 2: paddr=00020020 vaddr=42010020 size=53a7ch (342652) map
I (163) esp_image: segment 3: paddr=00073aa4 vaddr=408028f8 size=02038h (  8248) load
I (166) boot: Loaded app from partition at offset 0x10000
I (167) boot: Disabling RNG early entropy source...
Device IEEE address: 0x[REDACTED_IEEE]
Joining EPID=0x[REDACTED_EPID] on channel 25...
DEBUG - [BDB] start network steering, EPID=IeeeAddress(0x[REDACTED_EPID]), channels=25..26
DEBUG - [MLME-SCAN] start scan
DEBUG - [MLME-SCAN] sent beacon frame to channel 25, waiting for messages...
DEBUG - [MLME-SCAN] waiting for response for 168960us
DEBUG - [MLME-SCAN] received beacon frame on channel 25
DEBUG - [MLME-SCAN] success
DEBUG - [NWK-JOIN] neighbor table: StorageVec(
    [
        NwkNeighbor {
            network_address: ShortAddress(0x005e),
            device_type: Router,
            rx_on_when_idle: false,
            end_device_configuration: 0,
            relationship: 3,
            transmit_failure: 0,
            lqi: 20,
            outgoing_cost: 0,
            age: 0,
            keepalive_received: false,
            extended_pan_id: IeeeAddress(0x[REDACTED_EPID]),
            logical_channel: 25,
            depth: 2,
            permit_joining: false,
            potential_parent: 1,
            router_capacity: true,
            end_device_capacity: true,
            update_id: 0,
            pan_id: [REDACTED_PAN_ID],
        },
    ],
)
WARN - [NWK-JOIN] no suitable neighbors
Join failed: NotPermitted
```