### PR TITLE
feat: NWK rejoin + BDB §7.1 init

### DIFF
--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -25,7 +25,6 @@ use zigbee::zdo::ZigbeeDevice;
 use zigbee::zdo::descriptor::DeviceDescriptorConfig;
 use zigbee::zdo::descriptor::EndpointDescriptor;
 use zigbee::zdo::descriptor::NodeDescriptorConfig;
-use zigbee::zdp::device_annce::DeviceAnnce;
 use zigbee_base_device_behavior::BaseDeviceBehavior;
 use zigbee_cluster_library::basic;
 use zigbee_cluster_library::basic::BasicServer;
@@ -198,63 +197,73 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
 
     if resume {
         println!(
-            "Resuming on network: addr={:#06x} pan={:#06x} channel={CHANNEL}",
+            "Resuming on network: addr={:#06x} pan={:#06x} channel={CHANNEL}, attempting rejoin...",
             *nib.network_address(),
             *nib.panid(),
         );
-        // announce the power cycle so the coordinator refreshes its state
-        let annce = DeviceAnnce {
-            nwk_addr: ShortAddress(*nib.network_address()),
-            ieee_addr: *nib.ieee_address(),
-            capability: CapabilityInformation(CAPABILITY),
-        };
-        if let Err(e) = device.device_annce(annce).await {
-            println!("Device_annce failed: {e:?}");
+    }
+
+    match bdb.start_initialization_procedure(device).await {
+        Ok(Some(confirm)) if confirm.status == NlmeJoinStatus::Success => {
+            println!(
+                "Rejoined: addr={:#06x} pan={:#06x} channel={CHANNEL}",
+                *nib.network_address(),
+                *nib.panid(),
+            );
         }
-    } else {
-        println!("Joining EPID={EXTENDED_PAN_ID:#018x} on channel {CHANNEL}...");
-        let join = bdb
-            .network_steering(
-                device,
-                &mut Delay,
-                IeeeAddress(EXTENDED_PAN_ID),
-                CHANNEL..CHANNEL + 1,
-                SCAN_DURATION,
-                CapabilityInformation(CAPABILITY),
-            )
-            .await;
-
-        match join {
-            Ok(confirm) if confirm.status == NlmeJoinStatus::Success => {
-                let nib = bdb.nib();
-                println!(
-                    "Joined: addr={:#06x} pan={:#06x} epid={:#x} update_id={}",
-                    *nib.network_address(),
-                    *nib.panid(),
-                    *nib.extended_panid(),
-                    nib.update_id()
-                );
-
-                let network_key = nib.security_material_set().first().unwrap().key;
-                println!("Network key installed: key={:02x?}", network_key);
-
-                let link_key = aib::get_ref()
-                    .device_key_pair_set()
-                    .first()
-                    .unwrap()
-                    .link_key;
-                println!("Link key installed: key={:02x?}", link_key);
+        init_result => {
+            // a prior rejoin attempt leaves the old network address/key
+            // material in the NIB; forget it before commissioning fresh so
+            // NLME-JOIN's "already joined" check does not reject it
+            if let Ok(Some(confirm)) = init_result {
+                println!("Rejoin failed ({:?}), forgetting network", confirm.status);
+                device.forget_network();
             }
-            Ok(confirm) => {
-                println!("Join failed: {:?}", confirm.status);
-                loop {
-                    Timer::after_secs(60).await;
+
+            println!("Joining EPID={EXTENDED_PAN_ID:#018x} on channel {CHANNEL}...");
+            let join = bdb
+                .network_steering(
+                    device,
+                    &mut Delay,
+                    IeeeAddress(EXTENDED_PAN_ID),
+                    CHANNEL..CHANNEL + 1,
+                    SCAN_DURATION,
+                    CapabilityInformation(CAPABILITY),
+                )
+                .await;
+
+            match join {
+                Ok(confirm) if confirm.status == NlmeJoinStatus::Success => {
+                    let nib = bdb.nib();
+                    println!(
+                        "Joined: addr={:#06x} pan={:#06x} epid={:#x} update_id={}",
+                        *nib.network_address(),
+                        *nib.panid(),
+                        *nib.extended_panid(),
+                        nib.update_id()
+                    );
+
+                    let network_key = nib.security_material_set().first().unwrap().key;
+                    println!("Network key installed: key={:02x?}", network_key);
+
+                    let link_key = aib::get_ref()
+                        .device_key_pair_set()
+                        .first()
+                        .unwrap()
+                        .link_key;
+                    println!("Link key installed: key={:02x?}", link_key);
                 }
-            }
-            Err(e) => {
-                println!("Join error: {e:#}");
-                loop {
-                    Timer::after_secs(60).await;
+                Ok(confirm) => {
+                    println!("Join failed: {:?}", confirm.status);
+                    loop {
+                        Timer::after_secs(60).await;
+                    }
+                }
+                Err(e) => {
+                    println!("Join error: {e:#}");
+                    loop {
+                        Timer::after_secs(60).await;
+                    }
                 }
             }
         }

--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -203,7 +203,7 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
         );
     }
 
-    match bdb.start_initialization_procedure(device).await {
+    match bdb.start_initialization_procedure(device, &mut Delay).await {
         Ok(Some(confirm)) if confirm.status == NlmeJoinStatus::Success => {
             println!(
                 "Rejoined: addr={:#06x} pan={:#06x} channel={CHANNEL}",

--- a/zigbee-base-device-behavior/src/lib.rs
+++ b/zigbee-base-device-behavior/src/lib.rs
@@ -12,6 +12,9 @@
 #![no_std]
 #![allow(unused)]
 
+#[cfg(test)]
+extern crate std;
+
 use core::future::Future;
 use core::future::poll_fn;
 use core::pin::pin;
@@ -94,16 +97,58 @@ impl BaseDeviceBehavior {
 
     /// Initialization procedure (BDB §7.1).
     ///
-    /// Restores persistent state and, if the node is already on a network,
-    /// attempts to rejoin it. Returns without error if the node is not on
-    /// a network — the caller should then invoke [`network_steering`].
+    /// Persistent state (NIB/AIB) must already be restored by the caller
+    /// before constructing the [`Nlme`]/[`ZigbeeDevice`] — that is step 1.
+    /// If the node is not on a network, or is not an end device, this
+    /// returns `Ok(None)` and the caller should invoke
+    /// [`Self::network_steering`].
+    ///
+    /// Otherwise it attempts an NWK rejoin (§3.2.2.13.3) against the
+    /// remembered network and returns the resulting confirm. A rejoin
+    /// failure is not retried here — per §7.1 step 5 that is the caller's
+    /// responsibility (e.g. falling back to [`Self::network_steering`] after
+    /// [`ZigbeeDevice::forget_network`]).
     pub async fn start_initialization_procedure<M: Mlme>(
         &mut self,
-        _device: &ZigbeeDevice<M>,
-    ) -> Result<(), NetworkError> {
-        // §7.1 step 1: restore persistent state (NIB/AIB backed by storage)
-        // §7.1 steps 2-8: TODO implement rejoin path
-        Ok(())
+        device: &ZigbeeDevice<M>,
+    ) -> Result<Option<NlmeJoinConfirm>, NetworkError> {
+        let nib = self.nib();
+
+        // §7.1 step 2
+        self.bdb_node_is_on_a_network = *nib.network_address() != 0xffff;
+        if !self.bdb_node_is_on_a_network {
+            return Ok(None);
+        }
+
+        // §7.1 step 3: only an end device attempts an automatic rejoin here;
+        // a router's channel-verification step (§7.1 steps 6-7) is not yet
+        // implemented.
+        if !self.is_end_device() {
+            return Ok(None);
+        }
+
+        // §7.1 step 4
+        log::debug!("[BDB] step 4: attempt NWK rejoin");
+        let capability_information = *nib.capability_information();
+        let request = NlmeJoinRequest {
+            extended_pan_id: IeeeAddress(*nib.extended_panid()),
+            rejoin_network: RejoinNetwork::NwkRejoin,
+            capability_information,
+            security_enabled: true,
+        };
+        let confirm = device.nlme().join(request).await;
+
+        // §7.1 step 5
+        if confirm.status == NlmeJoinStatus::Success {
+            log::debug!("[BDB] step 5: rejoin succeeded, broadcasting Device_annce");
+            Self::device_annce(device, capability_information).await?;
+            self.bdb_commissioning_status = BdbCommissioningStatus::Success;
+        } else {
+            log::warn!("[BDB] step 5: rejoin failed ({:?})", confirm.status);
+            self.bdb_commissioning_status = BdbCommissioningStatus::NoNetwork;
+        }
+
+        Ok(Some(confirm))
     }
 
     /// Network steering procedure for a node NOT on a network
@@ -380,4 +425,120 @@ pub enum BdbError {
 
     #[error("no open network discovered to join")]
     NoNetwork,
+}
+
+#[cfg(test)]
+mod tests {
+    use core::future::Future;
+
+    use zigbee::nwk::nib;
+    use zigbee_mac::Address;
+    use zigbee_mac::mlme::AssociationResponse;
+    use zigbee_mac::mlme::MacError;
+    use zigbee_mac::mlme::ScanResult;
+    use zigbee_mac::mlme::ScanType;
+
+    use super::*;
+
+    #[allow(clippy::panic)]
+    fn block_on<F: Future>(f: F) -> F::Output {
+        use core::pin::pin;
+        use core::task::Context;
+        use core::task::Poll;
+        use core::task::RawWaker;
+        use core::task::RawWakerVTable;
+        use core::task::Waker;
+
+        fn noop(_: *const ()) {}
+        fn clone(p: *const ()) -> RawWaker {
+            RawWaker::new(p, &VTABLE)
+        }
+        static VTABLE: RawWakerVTable = RawWakerVTable::new(clone, noop, noop, noop);
+
+        let waker = unsafe { Waker::from_raw(RawWaker::new(core::ptr::null(), &VTABLE)) };
+        let mut cx = Context::from_waker(&waker);
+        let mut f = pin!(f);
+
+        match f.as_mut().poll(&mut cx) {
+            Poll::Ready(val) => val,
+            Poll::Pending => panic!("block_on: future returned Pending"),
+        }
+    }
+
+    mockall::mock! {
+        Mlme {}
+        impl Mlme for Mlme {
+            fn ieee_address(&self) -> IeeeAddress;
+            async fn scan_network(
+                &self,
+                ty: ScanType,
+                channels: core::ops::Range<u8>,
+                duration: u8,
+            ) -> Result<ScanResult, MacError>;
+            async fn associate(
+                &self,
+                channel: u8,
+                dest: Address,
+                capabilities: zigbee_mac::CapabilityInformation,
+            ) -> Result<AssociationResponse, MacError>;
+            async fn poll_data(
+                &self,
+                coord_address: Address,
+                buf: &mut [u8],
+            ) -> Result<(usize, u8), MacError>;
+            async fn receive(
+                &self,
+                buf: &mut [u8],
+            ) -> Result<(usize, u8), MacError>;
+            async fn transmit_data(
+                &self,
+                dest: Address,
+                payload: &[u8],
+            ) -> Result<(), MacError>;
+        }
+    }
+
+    fn make_device(device_type: LogicalType) -> ZigbeeDevice<MockMlme> {
+        let mut mac = MockMlme::new();
+        mac.expect_ieee_address()
+            .return_const(IeeeAddress(0xa4c1_0000_0000_0001));
+        let nlme = Nlme::new(mac);
+        let config = Config {
+            device_type,
+            ..Config::default()
+        };
+        ZigbeeDevice::new(config, nlme)
+    }
+
+    // NIB is a process-wide singleton with a non-cfg(test) `init()` (no
+    // `try_init`/`reset` outside the `zigbee` crate itself), so every case
+    // that needs it lives in one #[test] to keep initialization order
+    // deterministic across the crate's test binary.
+    #[test]
+    fn start_initialization_procedure_early_returns() {
+        nib::init();
+        zigbee::aps::aib::init();
+
+        // §7.1 step 2: not on a network (fresh NIB, network_address=0xffff)
+        let device = make_device(LogicalType::EndDevice);
+        let mut bdb = BaseDeviceBehavior::new(Config {
+            device_type: LogicalType::EndDevice,
+            ..Config::default()
+        });
+        let result = block_on(bdb.start_initialization_procedure(&device));
+        assert!(matches!(result, Ok(None)));
+        assert!(!bdb.bdb_node_is_on_a_network);
+
+        // §7.1 step 3: on a network, but not an end device — no mac calls
+        // are expected here since the router-side MockMlme has none set up
+        nib::get_ref().update_network_address(|value| *value = 0x1234);
+        let router_device = make_device(LogicalType::Router);
+        let mut router_bdb = BaseDeviceBehavior::new(Config {
+            device_type: LogicalType::Router,
+            ..Config::default()
+        });
+        let result = block_on(router_bdb.start_initialization_procedure(&router_device));
+        assert!(matches!(result, Ok(None)));
+        assert!(router_bdb.bdb_node_is_on_a_network);
+    }
 }

--- a/zigbee-base-device-behavior/src/lib.rs
+++ b/zigbee-base-device-behavior/src/lib.rs
@@ -60,6 +60,7 @@ use zigbee_mac::mlme::Mlme;
 use zigbee_types::ByteArray;
 use zigbee_types::IeeeAddress;
 use zigbee_types::ShortAddress;
+use zigbee_types::sync::with_timeout;
 
 /// Base Device Behavior (BDB) commissioning manager.
 ///
@@ -104,13 +105,15 @@ impl BaseDeviceBehavior {
     /// [`Self::network_steering`].
     ///
     /// Otherwise it attempts an NWK rejoin (§3.2.2.13.3) against the
-    /// remembered network and returns the resulting confirm. A rejoin
-    /// failure is not retried here — per §7.1 step 5 that is the caller's
-    /// responsibility (e.g. falling back to [`Self::network_steering`] after
-    /// [`ZigbeeDevice::forget_network`]).
+    /// remembered network and, on success, renegotiates the end-device
+    /// timeout (§3.6.10.2) and broadcasts a Device_annce before returning the
+    /// confirm. A rejoin failure is not retried here — per §7.1 step 5 that is
+    /// the caller's responsibility (e.g. falling back to
+    /// [`Self::network_steering`] after [`ZigbeeDevice::forget_network`]).
     pub async fn start_initialization_procedure<M: Mlme>(
         &mut self,
         device: &ZigbeeDevice<M>,
+        delay: &mut impl DelayNs,
     ) -> Result<Option<NlmeJoinConfirm>, NetworkError> {
         let nib = self.nib();
 
@@ -140,6 +143,10 @@ impl BaseDeviceBehavior {
 
         // §7.1 step 5
         if confirm.status == NlmeJoinStatus::Success {
+            // §3.6.10.2: the timeout is renegotiated after every rejoin, even
+            // with the same parent
+            Self::negotiate_end_device_timeout(device, delay).await;
+
             log::debug!("[BDB] step 5: rejoin succeeded, broadcasting Device_annce");
             Self::device_annce(device, capability_information).await?;
             self.bdb_commissioning_status = BdbCommissioningStatus::Success;
@@ -175,6 +182,11 @@ impl BaseDeviceBehavior {
             "[BDB] start network steering, EPID={extended_pan_id:?}, channels={channels:?}"
         );
         self.bdb_commissioning_status = BdbCommissioningStatus::InProgress;
+
+        // a node steering onto a network holds no valid link keys for it: any
+        // left over from an earlier network would reject the Trust Center's
+        // Transport-Key (§4.4.10)
+        device.reset_trust_center_link_keys();
 
         // §8.2 step 1
         device
@@ -403,21 +415,6 @@ impl BaseDeviceBehavior {
 }
 
 /// resolve `fut`, or `None` if `timeout` fires first
-async fn with_timeout<F: Future>(fut: F, timeout: impl Future<Output = ()>) -> Option<F::Output> {
-    let mut fut = pin!(fut);
-    let mut timeout = pin!(timeout);
-    poll_fn(move |cx| {
-        if let Poll::Ready(value) = fut.as_mut().poll(cx) {
-            return Poll::Ready(Some(value));
-        }
-        match timeout.as_mut().poll(cx) {
-            Poll::Ready(()) => Poll::Ready(None),
-            Poll::Pending => Poll::Pending,
-        }
-    })
-    .await
-}
-
 #[derive(Debug, Error)]
 pub enum BdbError {
     #[error("network error")]
@@ -469,6 +466,7 @@ mod tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
+            async fn set_short_address(&self, address: ShortAddress);
             async fn scan_network(
                 &self,
                 ty: ScanType,
@@ -498,6 +496,13 @@ mod tests {
         }
     }
 
+    /// Delay that returns immediately, so `block_on` never sees `Pending`.
+    struct NoopDelay;
+
+    impl DelayNs for NoopDelay {
+        async fn delay_ns(&mut self, _ns: u32) {}
+    }
+
     fn make_device(device_type: LogicalType) -> ZigbeeDevice<MockMlme> {
         let mut mac = MockMlme::new();
         mac.expect_ieee_address()
@@ -525,7 +530,7 @@ mod tests {
             device_type: LogicalType::EndDevice,
             ..Config::default()
         });
-        let result = block_on(bdb.start_initialization_procedure(&device));
+        let result = block_on(bdb.start_initialization_procedure(&device, &mut NoopDelay));
         assert!(matches!(result, Ok(None)));
         assert!(!bdb.bdb_node_is_on_a_network);
 
@@ -537,7 +542,8 @@ mod tests {
             device_type: LogicalType::Router,
             ..Config::default()
         });
-        let result = block_on(router_bdb.start_initialization_procedure(&router_device));
+        let result =
+            block_on(router_bdb.start_initialization_procedure(&router_device, &mut NoopDelay));
         assert!(matches!(result, Ok(None)));
         assert!(router_bdb.bdb_node_is_on_a_network);
     }

--- a/zigbee-mac/src/esp/mod.rs
+++ b/zigbee-mac/src/esp/mod.rs
@@ -658,6 +658,17 @@ impl Mlme for EspMlme<'_> {
         zigbee_types::IeeeAddress(self.ieee_address)
     }
 
+    async fn set_short_address(&self, address: zigbee_types::ShortAddress) {
+        self.inner
+            .lock()
+            .await
+            .driver
+            .update_driver_config(|config| {
+                config.promiscuous = false;
+                config.short_addr = Some(address.0);
+            });
+    }
+
     async fn scan_network(
         &self,
         ty: ScanType,

--- a/zigbee-mac/src/mlme.rs
+++ b/zigbee-mac/src/mlme.rs
@@ -36,6 +36,14 @@ pub trait Mlme {
     /// e.g. read from efuse.
     fn ieee_address(&self) -> IeeeAddress;
 
+    /// MLME-SET.request of `macShortAddress` (IEEE 802.15.4 §7.4.2).
+    ///
+    /// Applies the address the network layer was assigned, so the hardware
+    /// filter accepts unicasts sent to it. [`Self::associate`] already does
+    /// this for the address it obtained; the NWK layer calls this when an
+    /// address is assigned by other means, e.g. a rejoin response.
+    async fn set_short_address(&self, address: ShortAddress);
+
     async fn scan_network(
         &self,
         ty: ScanType,

--- a/zigbee-types/Cargo.toml
+++ b/zigbee-types/Cargo.toml
@@ -12,6 +12,7 @@ atomic-waker.workspace = true
 byte.workspace = true
 itertools.workspace = true
 heapless.workspace = true
+spin.workspace = true
 embedded-storage.workspace = true
 
 zigbee-macros = { version = "0.1.0", path = "../zigbee-macros" }

--- a/zigbee-types/src/sync.rs
+++ b/zigbee-types/src/sync.rs
@@ -2,12 +2,99 @@
 //!
 //! Runtime-agnostic: built on [`AtomicWaker`], usable from any executor.
 
+use core::future::Future;
 use core::future::poll_fn;
+use core::pin::pin;
 use core::sync::atomic::AtomicBool;
 use core::sync::atomic::Ordering;
 use core::task::Poll;
 
 use atomic_waker::AtomicWaker;
+use spin::Mutex;
+
+/// Run `fut` until it completes or `timeout` elapses first.
+///
+/// Returns `None` when `timeout` won the race.
+pub async fn with_timeout<F: Future>(
+    fut: F,
+    timeout: impl Future<Output = ()>,
+) -> Option<F::Output> {
+    let mut fut = pin!(fut);
+    let mut timeout = pin!(timeout);
+    poll_fn(move |cx| {
+        if let Poll::Ready(value) = fut.as_mut().poll(cx) {
+            return Poll::Ready(Some(value));
+        }
+        match timeout.as_mut().poll(cx) {
+            Poll::Ready(()) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    })
+    .await
+}
+
+/// One-shot signal carrying a value to a single waiter.
+///
+/// The value is produced by the receive path and consumed by the procedure
+/// waiting for it; it stays available until taken, so a signal that arrives
+/// before anyone waits is not lost.
+pub struct Signal<T> {
+    value: Mutex<Option<T>>,
+    waker: AtomicWaker,
+}
+
+impl<T> Default for Signal<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl<T> Signal<T> {
+    /// Creates a signal holding no value.
+    pub const fn new() -> Self {
+        Self {
+            value: Mutex::new(None),
+            waker: AtomicWaker::new(),
+        }
+    }
+
+    /// Store the value and wake the waiter, replacing an unconsumed one.
+    pub fn signal(&self, value: T) {
+        *self.value.lock() = Some(value);
+        self.waker.wake();
+    }
+
+    /// Discard a pending, unconsumed value.
+    pub fn reset(&self) {
+        *self.value.lock() = None;
+    }
+
+    /// Take the value without waiting, if one is pending.
+    pub fn try_take(&self) -> Option<T> {
+        self.value.lock().take()
+    }
+
+    /// Whether a value is pending.
+    pub fn is_signaled(&self) -> bool {
+        self.value.lock().is_some()
+    }
+
+    /// Wait until signaled, consuming the value.
+    pub async fn wait(&self) -> T {
+        poll_fn(|cx| {
+            if let Some(value) = self.try_take() {
+                return Poll::Ready(value);
+            }
+            self.waker.register(cx.waker());
+            // re-check to close the race with a signal between check and register
+            match self.try_take() {
+                Some(value) => Poll::Ready(value),
+                None => Poll::Pending,
+            }
+        })
+        .await
+    }
+}
 
 /// One-shot event flag supporting a single waiter.
 #[derive(Default)]
@@ -91,6 +178,22 @@ mod tests {
         // flag consumed: next wait is pending again
         let mut wait = pin!(event.wait());
         assert!(wait.as_mut().poll(&mut cx).is_pending());
+    }
+
+    #[test]
+    fn signal_delivers_value_once() {
+        let signal = Signal::<u8>::new();
+        let mut cx = Context::from_waker(Waker::noop());
+
+        let mut wait = pin!(signal.wait());
+        assert!(wait.as_mut().poll(&mut cx).is_pending());
+
+        signal.signal(0x42);
+        assert_eq!(wait.as_mut().poll(&mut cx), Poll::Ready(0x42));
+
+        // value consumed: next wait is pending again
+        assert!(!signal.is_signaled());
+        assert!(pin!(signal.wait()).poll(&mut cx).is_pending());
     }
 
     #[test]

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -34,6 +34,7 @@ use byte::BytesExt;
 use zigbee_types::IeeeAddress;
 use zigbee_types::ShortAddress;
 use zigbee_types::sync::Event;
+use zigbee_types::sync::Signal;
 
 use super::aib;
 use super::aib::Aib;
@@ -102,11 +103,9 @@ pub(crate) struct Apsme {
     tc_exchange_active: AtomicBool,
     /// signaled when a TC link key was received and installed (§4.4.10)
     pub(crate) tc_key_received: Event,
-    /// signaled when the TC answered the key verification (§4.4.9)
-    pub(crate) tc_key_verified: Event,
-    /// status of the last Confirm-Key (§4.4.9), valid once
-    /// [`Self::tc_key_verified`] fired
-    tc_confirm_status: AtomicU8,
+    /// carries the Confirm-Key status (§4.4.9) once the TC answered the key
+    /// verification (0x00 = success)
+    pub(crate) tc_key_verified: Signal<u8>,
 }
 
 impl Apsme {
@@ -118,8 +117,7 @@ impl Apsme {
             aps_counter: AtomicU8::new(0),
             tc_exchange_active: AtomicBool::new(false),
             tc_key_received: Event::new(),
-            tc_key_verified: Event::new(),
-            tc_confirm_status: AtomicU8::new(0),
+            tc_key_verified: Signal::new(),
         }
     }
 
@@ -135,12 +133,6 @@ impl Apsme {
     /// are ignored again.
     pub(crate) fn end_tc_key_exchange(&self) {
         self.tc_exchange_active.store(false, Ordering::Release);
-    }
-
-    /// Status of the last Confirm-Key (0x00 = success), valid after
-    /// [`Self::tc_key_verified`] fired.
-    pub(crate) fn tc_confirm_status(&self) -> u8 {
-        self.tc_confirm_status.load(Ordering::Acquire)
     }
 
     /// Next APS counter value (§4.4.11), wrapping.
@@ -313,9 +305,7 @@ impl Apsme {
                 if confirm.status == 0x00 {
                     self.mark_tc_link_key_verified(aib);
                 }
-                self.tc_confirm_status
-                    .store(confirm.status, Ordering::Release);
-                self.tc_key_verified.signal();
+                self.tc_key_verified.signal(confirm.status);
             }
             // key transport (§4.4.3): the network key is obtained inline during
             // join; an unsolicited key update would be handled here
@@ -685,6 +675,7 @@ mod tests {
         use core::future::Future;
         use core::pin::pin;
         use core::task::Context;
+        use core::task::Poll;
         use core::task::Waker;
 
         let apsme = Apsme::new();
@@ -699,16 +690,20 @@ mod tests {
             aib.device_key_pair_set()[0].key_attributes,
             KeyAttribute::UnverifiedKey
         );
-        assert!(pin!(apsme.tc_key_verified.wait()).poll(&mut cx).is_ready());
-        assert_eq!(apsme.tc_confirm_status(), 0x01);
+        assert_eq!(
+            pin!(apsme.tc_key_verified.wait()).poll(&mut cx),
+            Poll::Ready(0x01)
+        );
 
         apsme.handle_aps_command(&aib, &confirm_key(0x00));
         assert_eq!(
             aib.device_key_pair_set()[0].key_attributes,
             KeyAttribute::VerifiedKey
         );
-        assert!(pin!(apsme.tc_key_verified.wait()).poll(&mut cx).is_ready());
-        assert_eq!(apsme.tc_confirm_status(), 0x00);
+        assert_eq!(
+            pin!(apsme.tc_key_verified.wait()).poll(&mut cx),
+            Poll::Ready(0x00)
+        );
     }
 
     #[test]

--- a/zigbee/src/nwk/nib/mod.rs
+++ b/zigbee/src/nwk/nib/mod.rs
@@ -267,7 +267,9 @@ impl CapabilityInformation {
 impl_byte! {
     #[derive(Debug, Clone)]
     pub struct NwkNeighbor {
-        //pub extended_address: IeeeAddress,
+        /// IEEE address of the neighbor, learned from received frames that
+        /// carry it; `IeeeAddress(0)` while unknown.
+        pub extended_address: IeeeAddress,
         pub network_address: ShortAddress,
         pub device_type: DeviceType,
         #[ctx = ()]

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -43,6 +43,8 @@ use zigbee_mac::mlme::ScanType;
 use zigbee_types::IeeeAddress;
 use zigbee_types::ShortAddress;
 use zigbee_types::StorageVec;
+use zigbee_types::sync::Signal;
+use zigbee_types::sync::with_timeout;
 
 use crate::nwk::frame::CommandFrame as NwkCommandFrame;
 use crate::nwk::frame::DataFrame as NwkDataFrame;
@@ -111,6 +113,9 @@ pub struct Nlme<M> {
     nwk_seq: AtomicU8,
     // requested timeout enum awaiting a response (§3.6.10.2); 0xff = none
     pending_timeout_request: AtomicU8,
+    // Rejoin Response (§3.4.7) handed from the receive path to the rejoin
+    // procedure waiting for it
+    rejoin_response: Signal<RejoinResponse>,
 }
 
 impl<M> Nlme<M>
@@ -129,6 +134,7 @@ where
             mac,
             nwk_seq: AtomicU8::new(0),
             pending_timeout_request: AtomicU8::new(NO_PENDING_TIMEOUT),
+            rejoin_response: Signal::new(),
         }
     }
 
@@ -182,20 +188,28 @@ where
         }
     }
 
-    /// Build a secured NWK command frame into `buf`, returning the total
-    /// frame length (§3.3.2).
+    /// Build a NWK command frame into `buf`, returning the total frame length
+    /// (§3.3.2).
+    ///
+    /// When `secure` is false the frame is sent in the clear, as required for
+    /// a Trust Center rejoin (§4.6.3.3.2).
     fn build_nwk_command_frame(
         &self,
         destination: ShortAddress,
         command: Command<'_>,
+        secure: bool,
         buf: &mut [u8],
     ) -> Result<usize, NetworkError> {
         let nib = self.nib();
+        // the destination IEEE address is carried whenever it is known
+        // (§3.4.6.2, §3.4.11.2)
+        let destination_ieee = self.neighbor_ieee_address(destination);
         let frame_control = NwkFrameControl(0)
             .set_frame_type(NwkFrameType::NwkCommand)
             .set_protocol_version(2)
             .set_discover_route(DiscoverRoute::Suppress)
-            .set_security_flag(true)
+            .set_security_flag(secure)
+            .set_destination_ieee_flag(destination_ieee.is_some())
             .set_source_ieee_flag(true);
 
         let header = NwkHeader {
@@ -204,16 +218,35 @@ where
             source: ShortAddress(*nib.network_address()),
             radius: 1,
             sequence_number: self.next_nwk_seq(),
-            destination_ieee: None,
+            destination_ieee,
             source_ieee: Some(*nib.ieee_address()),
             multicast_control: None,
             source_route_subframe: None,
         };
 
+        if !secure {
+            let offset = &mut 0;
+            buf.write_with(offset, header, ())?;
+            buf.write_with(offset, command, ())?;
+            return Ok(*offset);
+        }
+
         let nwk_frame = NwkFrame::NwkCommand(NwkCommandFrame { header, command });
         let cx = SecurityContext::get();
         let len = cx.encrypt_nwk_frame_in_place(nwk_frame, buf)?;
         Ok(len)
+    }
+
+    /// Build a failed NLME-JOIN.confirm (§3.2.2.13.3).
+    fn join_failure(status: NlmeJoinStatus) -> NlmeJoinConfirm {
+        NlmeJoinConfirm {
+            status,
+            network_address: ShortAddress(0xffff),
+            extended_pan_id: IeeeAddress(0u64),
+            channel: 0,
+            enhanced_beacon_type: false,
+            mac_interface_index: 0u8,
+        }
     }
 
     /// Send an End Device Timeout Request to the parent (§3.6.10.2).
@@ -231,7 +264,8 @@ where
         });
 
         let mut buf = [0u8; 256];
-        let len = self.build_nwk_command_frame(self.parent_short_address()?, command, &mut buf)?;
+        let len =
+            self.build_nwk_command_frame(self.parent_short_address()?, command, true, &mut buf)?;
         self.pending_timeout_request
             .store(requested_timeout, Ordering::Relaxed);
         self.mac
@@ -361,6 +395,33 @@ where
         Ok(addr)
     }
 
+    /// The IEEE address of a neighbor, once it has been learned from a
+    /// received frame carrying the source IEEE address field.
+    fn neighbor_ieee_address(&self, network_address: ShortAddress) -> Option<IeeeAddress> {
+        self.nib()
+            .neighbor_table()
+            .iter()
+            .find(|n| n.network_address == network_address)
+            .map(|n| n.extended_address)
+            .filter(|ieee| ieee.0 != 0)
+    }
+
+    /// Record the IEEE address a received frame reported for its source
+    /// (§3.4.6.2: it lets us address later commands by both addresses).
+    fn learn_neighbor_ieee_address(&self, header: &NwkHeader<'_>) {
+        let Some(source_ieee) = header.source_ieee else {
+            return;
+        };
+        self.nib().update_neighbor_table(|table| {
+            if let Some(neighbor) = table
+                .iter_mut()
+                .find(|n| n.network_address == header.source)
+            {
+                neighbor.extended_address = source_ieee;
+            }
+        });
+    }
+
     /// Find the parent's network address from the neighbor table.
     fn parent_short_address(&self) -> Result<ShortAddress, NetworkError> {
         let table = self.nib().neighbor_table();
@@ -421,12 +482,16 @@ where
         let nwk_frame = cx.decrypt_nwk_frame_in_place(frame_buf)?;
 
         match nwk_frame {
-            NwkFrame::Data(data_frame) => Ok(Some(data_frame)),
+            NwkFrame::Data(data_frame) => {
+                self.learn_neighbor_ieee_address(&data_frame.header);
+                Ok(Some(data_frame))
+            }
             // NWK command frames (link status, route requests, rejoin, ...) ride
             // the same receive path; let the NWK layer process them, then report
             // "no data" so the APS/ZDO caller skips this frame.
             NwkFrame::NwkCommand(command_frame) => {
-                self.handle_nwk_command(&command_frame.command);
+                self.learn_neighbor_ieee_address(&command_frame.header);
+                self.handle_nwk_command(command_frame.command);
                 Ok(None)
             }
             _ => Ok(None),
@@ -439,7 +504,7 @@ where
     /// handler can be filled in. Most are not yet acted upon — they are logged
     /// and ignored. Returning unit keeps the caller's receive loop simple; add
     /// a result type here if a handler needs to surface failures.
-    fn handle_nwk_command(&self, command: &Command<'_>) {
+    fn handle_nwk_command(&self, command: Command<'_>) {
         match command {
             // routing (§3.4.1–3.4.2): a sleepy end device routes via its parent,
             // so route discovery is currently a no-op.
@@ -452,9 +517,24 @@ where
             Command::NetworkUpdate(_) => log::trace!("[NWK] network update (ignored)"),
             // TODO: a Leave addressed to us should clear NIB state and re-commission.
             Command::Leave(_) => log::trace!("[NWK] leave (ignored)"),
-            // rejoin (§3.4.6–3.4.7): handled inline by the join/rejoin procedures.
+            // rejoin (§3.4.6–3.4.7): a request is parent-side only; a response
+            // is handed to the rejoin procedure waiting for it, which may be
+            // driven by another task than this receive path
             Command::RejoinRequest(_) => log::trace!("[NWK] rejoin request (ignored)"),
-            Command::RejoinResponse(_) => log::trace!("[NWK] rejoin response (ignored)"),
+            Command::RejoinResponse(response) => {
+                log::debug!(
+                    "[NWK] rejoin response: address={:?}, status={:#04x}",
+                    response.network_address,
+                    response.status
+                );
+                if response.status == u8::from(AssociationStatus::Successful) {
+                    // §3.4.7.3.1: the parent may hand out a different address
+                    // than the one the device rejoined with
+                    self.nib()
+                        .update_network_address(|value| *value = response.network_address.0);
+                }
+                self.rejoin_response.signal(response);
+            }
             // link management (§3.4.8, §3.4.13).
             Command::LinkStatus(_) => log::trace!("[NWK] link status (ignored)"),
             Command::LinkPowerDelta(_) => log::trace!("[NWK] link power delta (ignored)"),
@@ -509,6 +589,9 @@ where
             .iter()
             .filter_map(|pd| match pd.coord_address {
                 Address::Short(_pan_id, short_address) => Some(NwkNeighbor {
+                    // a beacon carries no IEEE address; learned later from
+                    // received frames
+                    extended_address: IeeeAddress(0),
                     network_address: ShortAddress(short_address.0),
                     device_type: if short_address.0 == NWK_COORDINATOR_ADDRESS {
                         DeviceType::Coordinator
@@ -601,14 +684,7 @@ where
         if request.rejoin_network == RejoinNetwork::NwkRejoin {
             return self.nwk_rejoin(request).await;
         }
-        let fail = |status: NlmeJoinStatus| NlmeJoinConfirm {
-            status,
-            network_address: ShortAddress(0xffff),
-            extended_pan_id: IeeeAddress(0u64),
-            channel: 0,
-            enhanced_beacon_type: false,
-            mac_interface_index: 0u8,
-        };
+        let fail = Self::join_failure;
 
         // --- Validate the request (§3.2.2.13.3) ---
 
@@ -755,23 +831,14 @@ where
     /// Request (§3.4.6) to the previously known parent and waits for the
     /// Rejoin Response (§3.4.7).
     ///
-    /// Only Secure Rejoin (§4.6.3.3.1) is implemented: the device must still
-    /// hold the network key it rejoins with, so `request.security_enabled`
-    /// must be `true`. Trust Center Rejoin (§4.6.3.3.2, unsecured, for a
-    /// device that lost its key) is not yet supported.
+    /// `request.security_enabled` selects the rejoin flavour: `true` secures
+    /// the Rejoin Request with the active network key (Secure Rejoin,
+    /// §4.6.3.3.1), `false` sends it unsecured (Trust Center Rejoin,
+    /// §4.6.3.3.2) for a device that no longer holds the key — the caller is
+    /// then responsible for obtaining the current network key from the Trust
+    /// Center.
     async fn nwk_rejoin(&self, request: NlmeJoinRequest) -> NlmeJoinConfirm {
-        let fail = |status: NlmeJoinStatus| NlmeJoinConfirm {
-            status,
-            network_address: ShortAddress(0xffff),
-            extended_pan_id: IeeeAddress(0u64),
-            channel: 0,
-            enhanced_beacon_type: false,
-            mac_interface_index: 0u8,
-        };
-
-        if !request.security_enabled {
-            return fail(NlmeJoinStatus::InvalidRequest);
-        }
+        let fail = Self::join_failure;
 
         // a rejoin only makes sense against a network this device already
         // remembers (BDB §7.1 step 4 only reaches here when
@@ -799,13 +866,19 @@ where
             ),
         });
 
-        let mut buf = [0u8; 64];
-        let Ok(len) = self.build_nwk_command_frame(parent, command, &mut buf) else {
-            return fail(NlmeJoinStatus::InvalidRequest);
+        let mut buf = [0u8; 128];
+        let Ok(len) =
+            self.build_nwk_command_frame(parent, command, request.security_enabled, &mut buf)
+        else {
+            return fail(NlmeJoinStatus::MacError);
         };
         let Ok(parent_addr) = self.parent_address() else {
             return fail(NlmeJoinStatus::InvalidRequest);
         };
+
+        // arm before transmitting: the response is delivered by the receive
+        // path, which may be this procedure's own poll or a concurrent loop
+        self.rejoin_response.reset();
         if self
             .mac
             .transmit_data(parent_addr, &buf[..len])
@@ -815,9 +888,8 @@ where
             return fail(NlmeJoinStatus::MacError);
         }
 
-        // §3.4.7.1: delivered indirectly to a sleepy child, so poll for it
-        let Ok(response) = self
-            .poll_rejoin_response(REJOIN_RESPONSE_POLL_RETRIES)
+        let Some(response) = self
+            .await_rejoin_response(REJOIN_RESPONSE_POLL_RETRIES)
             .await
         else {
             return fail(NlmeJoinStatus::MacError);
@@ -833,8 +905,9 @@ where
             return fail(NlmeJoinStatus::MacError);
         }
 
-        self.nib()
-            .update_network_address(|value| *value = response.network_address.0);
+        // the receive path stored the assigned address; the hardware filter has
+        // to follow it
+        self.mac.set_short_address(response.network_address).await;
 
         NlmeJoinConfirm {
             status: NlmeJoinStatus::Success,
@@ -849,25 +922,41 @@ where
         }
     }
 
-    /// Poll the parent for the Rejoin Response to a just-sent Rejoin Request,
-    /// retrying up to `retries` times.
-    async fn poll_rejoin_response(&self, retries: u8) -> Result<RejoinResponse, NetworkError> {
+    /// Wait for the receive path to deliver the Rejoin Response (§3.4.7).
+    ///
+    /// A concurrently running receive loop may deliver it; otherwise the
+    /// bounded polling below does.
+    async fn await_rejoin_response(&self, retries: u8) -> Option<RejoinResponse> {
+        with_timeout(
+            self.rejoin_response.wait(),
+            self.poll_until_rejoin_response(retries),
+        )
+        .await
+        // the response may have arrived in the very poll that ended the polling
+        .or_else(|| self.rejoin_response.try_take())
+    }
+
+    /// Poll the parent until the Rejoin Response has been processed or
+    /// `retries` polls went unanswered.
+    ///
+    /// Drives reception for a caller whose receive loop is not running yet; a
+    /// data frame cannot be dispatched from here and is left to that loop.
+    async fn poll_until_rejoin_response(&self, retries: u8) {
         let mut buf = [0u8; 128];
         for _ in 0..retries {
-            let Some(len) = self.poll_parent(&mut buf).await? else {
-                continue;
-            };
-            let cx = SecurityContext::get();
-            let Ok(nwk_frame) = cx.decrypt_nwk_frame_in_place(&mut buf[..len]) else {
-                continue;
-            };
-            if let NwkFrame::NwkCommand(command_frame) = nwk_frame
-                && let Command::RejoinResponse(response) = command_frame.command
-            {
-                return Ok(response);
+            if self.rejoin_response.is_signaled() {
+                return;
+            }
+            match self.poll_parent(&mut buf).await {
+                Ok(Some(len)) => match self.process_received_nwk_frame(&mut buf[..len]) {
+                    Ok(Some(_)) => log::debug!("[NWK-REJOIN] polled data frame dropped"),
+                    Ok(None) => (),
+                    Err(e) => log::debug!("[NWK-REJOIN] polled frame not processed: {e:?}"),
+                },
+                Ok(None) => (),
+                Err(e) => log::debug!("[NWK-REJOIN] poll failed: {e:?}"),
             }
         }
-        Err(NetworkError::MacError(MacError::NoData))
     }
 
     /// Poll the coordinator for pending data, strip the NWK header, and
@@ -991,6 +1080,7 @@ mod tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
+            async fn set_short_address(&self, address: ShortAddress);
             async fn scan_network(
                 &self,
                 ty: ScanType,
@@ -1027,6 +1117,7 @@ mod tests {
     /// Create a default `NwkNeighbor` pre-filled for parent selection.
     fn make_neighbor(pan_id: u16, short_addr: u16, epid: u64, lqi: u8, depth: u8) -> NwkNeighbor {
         NwkNeighbor {
+            extended_address: IeeeAddress(0),
             network_address: ShortAddress(short_addr),
             device_type: if short_addr == 0 {
                 DeviceType::Coordinator
@@ -1483,16 +1574,27 @@ mod tests {
     }
 
     #[test]
-    fn nwk_rejoin_requires_security_enabled() {
-        // no mac expectations set: any call would panic the mock
-        let (_guard, nlme) = make_nlme(MockMlme::new());
+    fn nwk_rejoin_without_security_is_sent_unsecured() {
+        // §4.6.3.3.2: a Trust Center rejoin carries no NWK security
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .withf(|_dest, payload| {
+                let (header, _) = NwkHeader::try_read(payload, ()).unwrap();
+                !header.frame_control.security_flag()
+            })
+            .returning(|_, _| Ok(()));
+        mac.expect_poll_data()
+            .returning(|_, _| Err(MacError::NoData));
+
+        let (_guard, nlme) = make_nlme(mac);
         seed_joined_nib(&nlme);
 
         let mut req = rejoin_request(0xDEAD);
         req.security_enabled = false;
 
         let confirm = block_on(nlme.join(req));
-        assert_eq!(confirm.status, NlmeJoinStatus::InvalidRequest);
+        assert_eq!(confirm.status, NlmeJoinStatus::MacError);
     }
 
     #[test]
@@ -1510,26 +1612,21 @@ mod tests {
         mac.expect_transmit_data()
             .times(1)
             .withf(|dest, payload| {
-                assert_eq!(
-                    *dest,
-                    Address::Short(PanId(0xAAAA), MacShortAddress(0x0000))
-                );
                 let mut buf = [0u8; 256];
                 buf[..payload.len()].copy_from_slice(payload);
-                let frame = SecurityContext::get()
-                    .decrypt_nwk_frame_in_place(&mut buf[..payload.len()])
-                    .unwrap();
-                let NwkFrame::NwkCommand(command_frame) = frame else {
-                    panic!("expected NWK command frame");
+                let Ok(NwkFrame::NwkCommand(command_frame)) =
+                    SecurityContext::get().decrypt_nwk_frame_in_place(&mut buf[..payload.len()])
+                else {
+                    return false;
                 };
                 let Command::RejoinRequest(request) = command_frame.command else {
-                    panic!("expected rejoin request");
+                    return false;
                 };
-                // rejoin_request() uses CapabilityInformation(0x80): allocate
-                // address set, device_type (end device) clear
-                assert_eq!(request.capability_information.device_type(), 0);
-                assert_eq!(request.capability_information.allocate_address(), 1);
-                true
+                *dest == Address::Short(PanId(0xAAAA), MacShortAddress(0x0000))
+                    // rejoin_request() uses CapabilityInformation(0x80):
+                    // allocate address set, device_type (end device) clear
+                    && request.capability_information.device_type() == 0
+                    && request.capability_information.allocate_address() == 1
             })
             .returning(|_, _| Ok(()));
         mac.expect_poll_data().times(1).returning(|_, buf| {
@@ -1537,6 +1634,11 @@ mod tests {
             buf[..response.len()].copy_from_slice(&response);
             Ok((response.len(), 200u8))
         });
+        // the assigned address has to reach the hardware filter
+        mac.expect_set_short_address()
+            .times(1)
+            .withf(|address| *address == ShortAddress(0x5678))
+            .returning(|_| ());
 
         let (_guard, nlme) = make_nlme(mac);
         seed_joined_nib(&nlme);
@@ -1545,6 +1647,22 @@ mod tests {
         assert_eq!(confirm.status, NlmeJoinStatus::Success);
         assert_eq!(confirm.network_address, ShortAddress(0x5678));
         assert_eq!(*nlme.nib().network_address(), 0x5678);
+    }
+
+    #[test]
+    fn rejoin_response_from_receive_path_applies_address_and_signals() {
+        // a concurrent receive loop may retrieve the response instead of the
+        // rejoin procedure's own poll
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        nlme.handle_nwk_command(Command::RejoinResponse(RejoinResponse {
+            network_address: ShortAddress(0x5678),
+            status: 0x00,
+        }));
+
+        assert_eq!(*nlme.nib().network_address(), 0x5678);
+        block_on(nlme.rejoin_response.wait());
     }
 
     #[test]
@@ -1685,7 +1803,7 @@ mod tests {
         let (_guard, nlme) = make_nlme(MockMlme::new());
         nlme.pending_timeout_request.store(0x03, Ordering::Relaxed);
 
-        nlme.handle_nwk_command(&Command::EndDeviceTimeoutResponse(
+        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
             EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_SUCCESS,
                 parent_information: 0b011,
@@ -1707,7 +1825,7 @@ mod tests {
         let (_guard, nlme) = make_nlme(MockMlme::new());
         nlme.pending_timeout_request.store(0x03, Ordering::Relaxed);
 
-        nlme.handle_nwk_command(&Command::EndDeviceTimeoutResponse(
+        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
             EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_INCORRECT_VALUE,
                 parent_information: 0b001,
@@ -1723,7 +1841,7 @@ mod tests {
     fn end_device_timeout_response_unsolicited_ignored() {
         let (_guard, nlme) = make_nlme(MockMlme::new());
 
-        nlme.handle_nwk_command(&Command::EndDeviceTimeoutResponse(
+        nlme.handle_nwk_command(Command::EndDeviceTimeoutResponse(
             EndDeviceTimeoutResponse {
                 status: EndDeviceTimeoutResponse::STATUS_SUCCESS,
                 parent_information: 0b001,

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -51,6 +51,9 @@ use crate::nwk::frame::command::Command;
 use crate::nwk::frame::command::end_device_timeout_request;
 use crate::nwk::frame::command::end_device_timeout_request::EndDeviceTimeoutRequest;
 use crate::nwk::frame::command::end_device_timeout_response::EndDeviceTimeoutResponse;
+use crate::nwk::frame::command::rejoin_request;
+use crate::nwk::frame::command::rejoin_request::RejoinRequest;
+use crate::nwk::frame::command::rejoin_response::RejoinResponse;
 use crate::nwk::frame::frame_control::DiscoverRoute;
 use crate::nwk::frame::frame_control::FrameControl as NwkFrameControl;
 use crate::nwk::frame::frame_control::FrameType as NwkFrameType;
@@ -71,6 +74,10 @@ pub mod management;
 
 // sentinel for `pending_timeout_request`: no request outstanding
 const NO_PENDING_TIMEOUT: u8 = 0xff;
+
+// poll attempts while waiting for the parent to deliver a buffered Rejoin
+// Response (§3.4.7.1: indirect transmission for a sleepy child)
+const REJOIN_RESPONSE_POLL_RETRIES: u8 = 20;
 
 #[derive(Debug, Error)]
 pub enum NetworkError {
@@ -587,7 +594,13 @@ where
     }
 
     /// 3.2.2.13
+    // the association candidate loop is a single state machine; splitting it
+    // up would scatter the §3.6.1.4.1.1 bookkeeping across functions
+    #[allow(clippy::too_many_lines)]
     pub async fn join(&self, request: NlmeJoinRequest) -> NlmeJoinConfirm {
+        if request.rejoin_network == RejoinNetwork::NwkRejoin {
+            return self.nwk_rejoin(request).await;
+        }
         let fail = |status: NlmeJoinStatus| NlmeJoinConfirm {
             status,
             network_address: ShortAddress(0xffff),
@@ -600,8 +613,7 @@ where
         // --- Validate the request (§3.2.2.13.3) ---
 
         // Only MAC association is handled here.
-        // Orphan (0x01), NWK rejoin (0x02), and channel change (0x03) are not yet
-        // implemented.
+        // Orphan (0x01) and channel change (0x03) are not yet implemented.
         if request.rejoin_network != RejoinNetwork::Association {
             return fail(NlmeJoinStatus::InvalidRequest);
         }
@@ -736,13 +748,126 @@ where
         fail(last_status)
     }
 
-    /// Convenience wrapper — issues a join with `RejoinNetwork::NwkRejoin`
-    /// (§3.2.2.13).
-    #[allow(clippy::unused_async)]
-    pub async fn rejoin(&self) -> NlmeJoinConfirm {
-        // TODO: implement NWK rejoin procedure (§3.6.1.4.2); afterwards send an
-        // End Device Timeout Request even when rejoining the same parent (§3.6.10.2)
-        todo!()
+    /// NLME-JOIN.request with `RejoinNetwork::NwkRejoin` (§3.2.2.13.3).
+    ///
+    /// Reconnects to a network this device remembers — extended PAN id,
+    /// parent, network key — without a fresh MLME-SCAN: it unicasts a Rejoin
+    /// Request (§3.4.6) to the previously known parent and waits for the
+    /// Rejoin Response (§3.4.7).
+    ///
+    /// Only Secure Rejoin (§4.6.3.3.1) is implemented: the device must still
+    /// hold the network key it rejoins with, so `request.security_enabled`
+    /// must be `true`. Trust Center Rejoin (§4.6.3.3.2, unsecured, for a
+    /// device that lost its key) is not yet supported.
+    async fn nwk_rejoin(&self, request: NlmeJoinRequest) -> NlmeJoinConfirm {
+        let fail = |status: NlmeJoinStatus| NlmeJoinConfirm {
+            status,
+            network_address: ShortAddress(0xffff),
+            extended_pan_id: IeeeAddress(0u64),
+            channel: 0,
+            enhanced_beacon_type: false,
+            mac_interface_index: 0u8,
+        };
+
+        if !request.security_enabled {
+            return fail(NlmeJoinStatus::InvalidRequest);
+        }
+
+        // a rejoin only makes sense against a network this device already
+        // remembers (BDB §7.1 step 4 only reaches here when
+        // bdbNodeIsOnANetwork is TRUE and the extended PAN id is known).
+        if *self.nib().network_address() == 0xffff
+            || *self.nib().extended_panid() != request.extended_pan_id.0
+        {
+            return fail(NlmeJoinStatus::InvalidRequest);
+        }
+        let Ok(parent) = self.parent_short_address() else {
+            return fail(NlmeJoinStatus::InvalidRequest);
+        };
+
+        // whether joining or rejoining, nwkParentInformation is reset
+        // (§3.2.2.13.3)
+        self.reset_parent_negotiation();
+        self.nib()
+            .update_capability_information(|value| *value = request.capability_information);
+
+        let command = Command::RejoinRequest(RejoinRequest {
+            // the Capability Information bit layout (Table 3-62) is shared
+            // with `nwk::nib::CapabilityInformation`
+            capability_information: rejoin_request::CapabilityInformation(
+                request.capability_information.0,
+            ),
+        });
+
+        let mut buf = [0u8; 64];
+        let Ok(len) = self.build_nwk_command_frame(parent, command, &mut buf) else {
+            return fail(NlmeJoinStatus::InvalidRequest);
+        };
+        let Ok(parent_addr) = self.parent_address() else {
+            return fail(NlmeJoinStatus::InvalidRequest);
+        };
+        if self
+            .mac
+            .transmit_data(parent_addr, &buf[..len])
+            .await
+            .is_err()
+        {
+            return fail(NlmeJoinStatus::MacError);
+        }
+
+        // §3.4.7.1: delivered indirectly to a sleepy child, so poll for it
+        let Ok(response) = self
+            .poll_rejoin_response(REJOIN_RESPONSE_POLL_RETRIES)
+            .await
+        else {
+            return fail(NlmeJoinStatus::MacError);
+        };
+
+        if response.status == u8::from(AssociationStatus::NetworkAtCapacity) {
+            return fail(NlmeJoinStatus::PanAtCapacity);
+        }
+        if response.status == u8::from(AssociationStatus::AccessDenied) {
+            return fail(NlmeJoinStatus::PanAccessDenied);
+        }
+        if response.status != u8::from(AssociationStatus::Successful) {
+            return fail(NlmeJoinStatus::MacError);
+        }
+
+        self.nib()
+            .update_network_address(|value| *value = response.network_address.0);
+
+        NlmeJoinConfirm {
+            status: NlmeJoinStatus::Success,
+            network_address: response.network_address,
+            extended_pan_id: request.extended_pan_id,
+            // the operating channel isn't tracked in the NIB — the caller is
+            // responsible for having the radio already tuned to it (BDB
+            // §7.1 step 4 passes ScanChannels=0: no scan is performed here).
+            channel: 0,
+            enhanced_beacon_type: false,
+            mac_interface_index: 0u8,
+        }
+    }
+
+    /// Poll the parent for the Rejoin Response to a just-sent Rejoin Request,
+    /// retrying up to `retries` times.
+    async fn poll_rejoin_response(&self, retries: u8) -> Result<RejoinResponse, NetworkError> {
+        let mut buf = [0u8; 128];
+        for _ in 0..retries {
+            let Some(len) = self.poll_parent(&mut buf).await? else {
+                continue;
+            };
+            let cx = SecurityContext::get();
+            let Ok(nwk_frame) = cx.decrypt_nwk_frame_in_place(&mut buf[..len]) else {
+                continue;
+            };
+            if let NwkFrame::NwkCommand(command_frame) = nwk_frame
+                && let Command::RejoinResponse(response) = command_frame.command
+            {
+                return Ok(response);
+            }
+        }
+        Err(NetworkError::MacError(MacError::NoData))
     }
 
     /// Poll the coordinator for pending data, strip the NWK header, and
@@ -1303,6 +1428,171 @@ mod tests {
     }
 
     // -------------------------------------------------------------------
+    // NWK rejoin tests (§3.2.2.13.3, §3.4.6/.7)
+    // -------------------------------------------------------------------
+
+    fn rejoin_request(epid: u64) -> NlmeJoinRequest {
+        NlmeJoinRequest {
+            extended_pan_id: IeeeAddress(epid),
+            rejoin_network: RejoinNetwork::NwkRejoin,
+            capability_information: CapabilityInformation(0x80),
+            security_enabled: true,
+        }
+    }
+
+    /// Build the encrypted bytes of an inbound Rejoin Response command frame,
+    /// as `poll_data` would deliver it from the parent.
+    fn encrypted_rejoin_response(network_address: u16, status: u8) -> heapless::Vec<u8, 128> {
+        let nib = nib::get_ref();
+        let header = NwkHeader {
+            frame_control: NwkFrameControl(0)
+                .set_frame_type(NwkFrameType::NwkCommand)
+                .set_protocol_version(2)
+                .set_discover_route(DiscoverRoute::Suppress)
+                .set_security_flag(true)
+                .set_source_ieee_flag(true),
+            destination: ShortAddress(*nib.network_address()),
+            source: ShortAddress(0x0000),
+            radius: 1,
+            sequence_number: 0,
+            destination_ieee: None,
+            source_ieee: Some(*nib.ieee_address()),
+            multicast_control: None,
+            source_route_subframe: None,
+        };
+        let command = Command::RejoinResponse(RejoinResponse {
+            network_address: ShortAddress(network_address),
+            status,
+        });
+        let nwk_frame = NwkFrame::NwkCommand(NwkCommandFrame { header, command });
+        let mut buf = heapless::Vec::<u8, 128>::new();
+        buf.resize(128, 0).unwrap();
+        let len = SecurityContext::get()
+            .encrypt_nwk_frame_in_place(nwk_frame, &mut buf)
+            .unwrap();
+        buf.truncate(len);
+        buf
+    }
+
+    #[test]
+    fn nwk_rejoin_not_joined_is_invalid() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::InvalidRequest);
+    }
+
+    #[test]
+    fn nwk_rejoin_requires_security_enabled() {
+        // no mac expectations set: any call would panic the mock
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let mut req = rejoin_request(0xDEAD);
+        req.security_enabled = false;
+
+        let confirm = block_on(nlme.join(req));
+        assert_eq!(confirm.status, NlmeJoinStatus::InvalidRequest);
+    }
+
+    #[test]
+    fn nwk_rejoin_epid_mismatch_is_invalid() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xBEEF)));
+        assert_eq!(confirm.status, NlmeJoinStatus::InvalidRequest);
+    }
+
+    #[test]
+    fn nwk_rejoin_success_sends_request_and_updates_address() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .withf(|dest, payload| {
+                assert_eq!(
+                    *dest,
+                    Address::Short(PanId(0xAAAA), MacShortAddress(0x0000))
+                );
+                let mut buf = [0u8; 256];
+                buf[..payload.len()].copy_from_slice(payload);
+                let frame = SecurityContext::get()
+                    .decrypt_nwk_frame_in_place(&mut buf[..payload.len()])
+                    .unwrap();
+                let NwkFrame::NwkCommand(command_frame) = frame else {
+                    panic!("expected NWK command frame");
+                };
+                let Command::RejoinRequest(request) = command_frame.command else {
+                    panic!("expected rejoin request");
+                };
+                // rejoin_request() uses CapabilityInformation(0x80): allocate
+                // address set, device_type (end device) clear
+                assert_eq!(request.capability_information.device_type(), 0);
+                assert_eq!(request.capability_information.allocate_address(), 1);
+                true
+            })
+            .returning(|_, _| Ok(()));
+        mac.expect_poll_data().times(1).returning(|_, buf| {
+            let response = encrypted_rejoin_response(0x5678, 0x00);
+            buf[..response.len()].copy_from_slice(&response);
+            Ok((response.len(), 200u8))
+        });
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::Success);
+        assert_eq!(confirm.network_address, ShortAddress(0x5678));
+        assert_eq!(*nlme.nib().network_address(), 0x5678);
+    }
+
+    #[test]
+    fn nwk_rejoin_network_at_capacity() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+        mac.expect_poll_data().times(1).returning(|_, buf| {
+            let response = encrypted_rejoin_response(0xffff, 0x01);
+            buf[..response.len()].copy_from_slice(&response);
+            Ok((response.len(), 200u8))
+        });
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::PanAtCapacity);
+    }
+
+    #[test]
+    fn nwk_rejoin_no_response_is_mac_error() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+        mac.expect_poll_data()
+            .returning(|_, _| Err(MacError::NoData));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::MacError);
+    }
+
+    #[test]
+    fn nwk_rejoin_transmit_failure_is_mac_error() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .returning(|_, _| Err(MacError::NoAck));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::MacError);
+    }
+
+    // -------------------------------------------------------------------
     // end device timeout tests (§3.6.10)
     // -------------------------------------------------------------------
 
@@ -1316,6 +1606,7 @@ mod tests {
         let nib = nlme.nib();
         nib.update_panid(|value| *value = 0xAAAA);
         nib.update_network_address(|value| *value = 0x1234);
+        nib.update_extended_panid(|value| *value = 0xDEAD);
 
         let mut table = StorageVec::new();
         let mut parent = make_neighbor(0xAAAA, 0x0000, 0xDEAD, 200, 0);

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -134,7 +134,8 @@ impl<M: Mlme> ZigbeeDevice<M> {
     }
 
     /// Forgets the joined network so the next boot re-commissions: clears the
-    /// network address and security material.
+    /// network address, the network key and the link keys negotiated with the
+    /// Trust Center.
     ///
     /// With flash-backed information bases, flush the storage before
     /// resetting so this state survives the reboot.
@@ -142,6 +143,18 @@ impl<M: Mlme> ZigbeeDevice<M> {
         let nib = nib::get_ref();
         nib.update_network_address(|value| *value = 0xffff);
         nib.update_security_material_set(|set| set.clear());
+        self.reset_trust_center_link_keys();
+    }
+
+    /// Drops the link keys negotiated with the Trust Center so commissioning
+    /// starts from the default TC link key again (§4.4.10).
+    ///
+    /// Link keys are per-network: a stale key pair also carries its anti-replay
+    /// counters, which reject the Transport-Key of a new join.
+    pub fn reset_trust_center_link_keys(&self) {
+        let aib = aib::get_ref();
+        aib.update_device_key_pair_set(|set| set.clear());
+        aib.update_trust_center_address(|value| *value = IeeeAddress(0xffff_ffff_ffff_ffff));
     }
 
     /// Access the owned NWK management entity (used by BDB during
@@ -371,8 +384,7 @@ impl<M: Mlme> ZigbeeDevice<M> {
     ///
     /// Bound the wait with an executor timeout.
     pub async fn wait_tc_link_key_verified(&self) -> u8 {
-        self.apsme.tc_key_verified.wait().await;
-        self.apsme.tc_confirm_status()
+        self.apsme.tc_key_verified.wait().await
     }
 
     /// Receive and dispatch one inbound APS data frame.


### PR DESCRIPTION
Joined the test network, reset the device and it re-joined the network as expected
```DEBUG - [MLME] tx data, len=47
DEBUG - [MLME-POLL] rx data len=47
DEBUG - [ZDO] rx profile=0x0104 cluster=0x0402 from 0x0000 ep 1->1
DEBUG - [ZDO] tx response cluster=0x0402 (4 bytes) to 0x0000
DEBUG - [MLME] tx data, len=49
DEBUG - [MLME-POLL] rx data len=39
DEBUG - [ZDO] rx profile=0x0104 cluster=0x0402 from 0x0000 ep 1->1
DEBUG - [MLME] tx data, len=53
Reported temperature: 2310 (seq=2)
DEBUG - [MLME-POLL] rx data len=39
DEBUG - [ZDO] rx profile=0x0104 cluster=0x0402 from 0x0000 ep 1->1
ESP-ROM:esp32c6-20220919
Build:Sep 19 2022
rst:0x15 (USB_UART_HPSYS),boot:0xc (SPI_FAST_FLASH_BOOT)
Saved PC:0x420442d8
SPIWP:0xee
mode:DIO, clock div:2
load:0x40875730,len:0x175c
load:0x4086b910,len:0xec8
load:0x4086e610,len:0x31c4
entry 0x4086b91a
I (23) boot: ESP-IDF v5.5.1-838-gd66ebb86d2e 2nd stage bootloader
I (23) boot: compile time Nov 27 2025 09:46:10
I (24) boot: chip revision: v0.1
I (24) boot: efuse block revision: v0.3
I (28) boot.esp32c6: SPI Speed      : 80MHz
I (32) boot.esp32c6: SPI Mode       : DIO
I (35) boot.esp32c6: SPI Flash Size : 4MB
I (39) boot: Enabling RNG early entropy source...
I (44) boot: Partition Table:
I (46) boot: ## Label            Usage          Type ST Offset   Length
I (53) boot:  0 nvs              WiFi data        01 02 00009000 00006000
I (59) boot:  1 phy_init         RF data          01 01 0000f000 00001000
I (66) boot:  2 factory          factory app      00 00 00010000 003f0000
I (72) boot: End of partition table
I (76) esp_image: segment 0: paddr=00010020 vaddr=42000020 size=0d4e8h ( 54504) map
I (93) esp_image: segment 1: paddr=0001d510 vaddr=40800000 size=02b08h ( 11016) load
I (97) esp_image: segment 2: paddr=00020020 vaddr=42010020 size=52578h (337272) map
I (162) esp_image: segment 3: paddr=000725a0 vaddr=40802b08 size=01e28h (  7720) load
I (166) boot: Loaded app from partition at offset 0x10000
I (166) boot: Disabling RNG early entropy source...
Device IEEE address: 0x[REDACTED_IEEE]
Resuming on network: addr=0x[REDACTED_ADDR] pan=0x[REDACTED_PAN] channel=25, attempting rejoin...
DEBUG - [BDB] step 4: attempt NWK rejoin
DEBUG - [MLME] tx data, len=47
DEBUG - [MLME-POLL] rx data len=46
DEBUG - [BDB] step 5: rejoin succeeded, broadcasting Device_annce
DEBUG - [MLME] tx data, len=57
Rejoined: addr=0x[REDACTED_ADDR] pan=0x[REDACTED_PAN] channel=25
DEBUG - [MLME] tx data, len=53
Reported temperature: 2300 (seq=1)```