### PR TITLE
feat(zdo): Power_Desc, Match_Desc, Identify, generic attr reads

### DIFF
--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -25,11 +25,14 @@ use zigbee::zdo::ZigbeeDevice;
 use zigbee::zdo::descriptor::DeviceDescriptorConfig;
 use zigbee::zdo::descriptor::EndpointDescriptor;
 use zigbee::zdo::descriptor::NodeDescriptorConfig;
+use zigbee::zdo::descriptor::PowerDescriptorConfig;
 use zigbee_base_device_behavior::BaseDeviceBehavior;
 use zigbee_cluster_library::basic;
 use zigbee_cluster_library::basic::BasicServer;
 use zigbee_cluster_library::common::data_types::SignedN;
 use zigbee_cluster_library::common::data_types::ZclDataType;
+use zigbee_cluster_library::identify;
+use zigbee_cluster_library::identify::IdentifyServer;
 use zigbee_cluster_library::measurement::temperature;
 use zigbee_cluster_library::profile;
 use zigbee_cluster_library::reporting::ConfigureReportingServer;
@@ -73,7 +76,11 @@ const COORDINATOR_ENDPOINT: u8 = 1;
 const CAPABILITY: u8 = 0x80;
 
 /// Clusters served on [`SENSOR_ENDPOINT`] (input/server side).
-static INPUT_CLUSTERS: [u16; 2] = [basic::CLUSTER_ID, temperature::CLUSTER_ID];
+static INPUT_CLUSTERS: [u16; 3] = [
+    basic::CLUSTER_ID,
+    identify::CLUSTER_ID,
+    temperature::CLUSTER_ID,
+];
 static OUTPUT_CLUSTERS: [u16; 0] = [];
 
 /// Endpoints advertised to the network for service discovery.
@@ -120,6 +127,13 @@ fn descriptor_config() -> DeviceDescriptorConfig<'static> {
             maximum_outgoing_transfer_size: 128,
             descriptor_capability_field: 0,
         },
+        // disposable battery (bit 2), on when stimulated, full charge
+        power: PowerDescriptorConfig {
+            current_power_mode: 0b0010,
+            available_power_sources: 0b0100,
+            current_power_source: 0b0100,
+            current_power_source_level: 0b1100,
+        },
         endpoints: &ENDPOINTS,
     }
 }
@@ -128,16 +142,31 @@ fn descriptor_config() -> DeviceDescriptorConfig<'static> {
 /// indirect-transaction persistence time.
 const POLL_INTERVAL_MS: u32 = 500;
 
+/// Identify state, shared between the receive task and the application.
+static IDENTIFY: IdentifyServer = IdentifyServer::new();
+
 /// Receive loop: idles until the join completes, then answers ZDP discovery,
-/// Basic-cluster reads, Configure Reporting requests, and APS commands
-/// (TC link key exchange).
+/// Basic-cluster and Identify reads, Identify commands, Configure Reporting
+/// requests, and APS commands (TC link key exchange).
 #[embassy_executor::task]
 async fn rx_task(device: &'static ZigbeeDevice<EspMlme<'static>>) {
     let cfg = descriptor_config();
-    let handler = (BASIC, ConfigureReportingServer);
+    let handler = (BASIC, ConfigureReportingServer, &IDENTIFY);
     device
         .rx_loop(&cfg, &handler, &mut Delay, POLL_INTERVAL_MS)
         .await
+}
+
+/// Counts the Identify state down once a second (ZCL 3.5.2.2.1); a real device
+/// would blink an LED here.
+#[embassy_executor::task]
+async fn identify_task() {
+    loop {
+        Timer::after_secs(1).await;
+        if IDENTIFY.is_identifying() {
+            println!("Identifying ({}s remaining)", IDENTIFY.tick(1));
+        }
+    }
 }
 
 #[esp_rtos::main]
@@ -194,6 +223,7 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
     // persist NIB/AIB changes as they happen, including the keys obtained
     // during commissioning
     spawner.spawn(storage_task(storage).expect("spawn storage_task"));
+    spawner.spawn(identify_task().expect("spawn identify_task"));
 
     if resume {
         println!(

--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -14,7 +14,10 @@ use esp_println::println;
 use esp_radio::ieee802154::Ieee802154;
 use esp_storage::FlashStorage;
 use static_cell::StaticCell;
+use zigbee::CurrentPowerMode;
+use zigbee::CurrentPowerSourceLevel;
 use zigbee::LogicalType;
+use zigbee::PowerSource;
 use zigbee::aps::aib;
 use zigbee::aps::apsde::ApsdeSapConfirmStatus;
 use zigbee::nwk::nib::CapabilityInformation;
@@ -127,12 +130,11 @@ fn descriptor_config() -> DeviceDescriptorConfig<'static> {
             maximum_outgoing_transfer_size: 128,
             descriptor_capability_field: 0,
         },
-        // disposable battery (bit 2), on when stimulated, full charge
         power: PowerDescriptorConfig {
-            current_power_mode: 0b0010,
-            available_power_sources: 0b0100,
-            current_power_source: 0b0100,
-            current_power_source_level: 0b1100,
+            current_power_mode: CurrentPowerMode::Stimulated,
+            available_power_sources: &[PowerSource::DisposableBattery],
+            current_power_source: PowerSource::DisposableBattery,
+            current_power_source_level: CurrentPowerSourceLevel::Full,
         },
         endpoints: &ENDPOINTS,
     }

--- a/zigbee-cluster-library/src/attributes.rs
+++ b/zigbee-cluster-library/src/attributes.rs
@@ -1,20 +1,25 @@
 //! Generic attribute access.
 //!
-//! See ZCL Section 2.5.1.
+//! See ZCL Section 2.5.1 / 2.5.3.
 //!
 //! A cluster server exposes its attributes by implementing [`AttributeSource`];
 //! [`handle_read_attributes`] then answers `Read Attributes` for it, so every
-//! cluster gets attribute reads without repeating the frame handling.
+//! cluster gets attribute reads without repeating the frame handling. A server
+//! with writable attributes additionally implements [`AttributeSink`] and is
+//! answered by [`handle_write_attributes`].
 
 use byte::BytesExt;
 use byte::TryRead;
 use heapless::Vec;
+use zigbee::zdo::ClusterRequest;
 use zigbee::zdo::ClusterRequestHandler;
 
 use crate::common::data_types::ZclDataType;
+use crate::frame::DefaultResponse;
 use crate::frame::GeneralCommand;
 use crate::frame::ReadAttributeResponse;
 use crate::frame::Status;
+use crate::frame::WriteAttributeStatus;
 use crate::frame::ZclFrame;
 use crate::header::ZclHeader;
 use crate::header::command_identifier::CommandIdentifier;
@@ -25,7 +30,7 @@ use crate::payload::ZclFramePayload;
 /// response disabled.
 pub(crate) const RESPONSE_FRAME_CONTROL: u8 = 0x18;
 
-// attribute records carried in one Read Attributes Response
+// attribute records carried in one response frame
 const MAX_RECORDS: usize = 16;
 
 /// A cluster server that can resolve attribute identifiers to values.
@@ -35,6 +40,13 @@ pub trait AttributeSource {
 
     /// Current value of `attribute_id`, or `None` when unsupported.
     fn attribute(&self, attribute_id: u16) -> Option<ZclDataType<'_>>;
+}
+
+/// A cluster server whose attributes can be written (ZCL 2.5.3).
+pub trait AttributeSink: AttributeSource {
+    /// Apply a write, returning the ZCL status for the record: `Success`,
+    /// `UnsupportedAttribute`, `ReadOnly`, `InvalidDataType` or `InvalidValue`.
+    fn set_attribute(&self, attribute_id: u16, value: &ZclDataType<'_>) -> Status;
 }
 
 /// Answer a `Read Attributes` request (ZCL 2.5.1) from `source`.
@@ -61,6 +73,8 @@ where
         return None;
     };
 
+    // more records than fit are dropped: a partial response beats none
+    // (ZCL 2.5.1.3)
     let mut records: Vec<ReadAttributeResponse<'_>, MAX_RECORDS> = Vec::new();
     for request in requests {
         let record = source.attribute(request.attribute_id).map_or(
@@ -75,17 +89,115 @@ where
                 value: Some(value),
             },
         );
-        records.push(record).ok()?;
+        if records.push(record).is_err() {
+            break;
+        }
     }
 
+    write_response(
+        frame.header.sequence_number,
+        CommandIdentifier::ReadAttributesResponse,
+        GeneralCommand::ReadAttributesResponse(records),
+        out,
+    )
+}
+
+/// Answer a `Write Attributes` request (ZCL 2.5.3) against `sink`.
+///
+/// Returns `None` for another cluster, another command, or an unparsable
+/// frame. Every record is attempted; the response carries a single `Success`
+/// record when they all succeeded (ZCL 2.5.4.1.2).
+pub fn handle_write_attributes<S>(
+    sink: &S,
+    cluster_id: u16,
+    asdu: &[u8],
+    out: &mut [u8],
+) -> Option<usize>
+where
+    S: AttributeSink + ?Sized,
+{
+    if cluster_id != sink.cluster_id() {
+        return None;
+    }
+
+    let (frame, _) = ZclFrame::try_read(asdu, ()).ok()?;
+    let ZclFramePayload::GeneralCommand(GeneralCommand::WriteAttributes(requests)) = frame.payload
+    else {
+        return None;
+    };
+
+    let mut records: Vec<WriteAttributeStatus, MAX_RECORDS> = Vec::new();
+    for request in &requests {
+        let status = sink.set_attribute(request.attribute_id, &request.value);
+        if status == Status::Success {
+            continue;
+        }
+        let record = WriteAttributeStatus {
+            status,
+            attribute_id: Some(request.attribute_id),
+        };
+        if records.push(record).is_err() {
+            break;
+        }
+    }
+
+    if records.is_empty() {
+        records
+            .push(WriteAttributeStatus {
+                status: Status::Success,
+                attribute_id: None,
+            })
+            .ok()?;
+    }
+
+    write_response(
+        frame.header.sequence_number,
+        CommandIdentifier::WriteAttributesResponse,
+        GeneralCommand::WriteAttributesResponse(records),
+        out,
+    )
+}
+
+/// Build a Default Response (ZCL 2.5.12) for the command `header` describes.
+///
+/// Returns `None` when the spec forbids one (2.5.12.2): the request was not
+/// unicast, or it disabled the default response. `status` reports how the
+/// command was handled — `UnsupCommand` for an unrecognized command id.
+pub fn default_response(
+    header: &ZclHeader,
+    unicast: bool,
+    status: Status,
+    out: &mut [u8],
+) -> Option<usize> {
+    if !unicast || header.frame_control.disable_default_response() {
+        return None;
+    }
+
+    write_response(
+        header.sequence_number,
+        CommandIdentifier::DefaultResponse,
+        GeneralCommand::DefaultResponse(DefaultResponse {
+            command_identifier: header.command_identifier.raw(),
+            status,
+        }),
+        out,
+    )
+}
+
+fn write_response(
+    sequence_number: u8,
+    command_identifier: CommandIdentifier,
+    payload: GeneralCommand<'_>,
+    out: &mut [u8],
+) -> Option<usize> {
     let response = ZclFrame {
         header: ZclHeader {
             frame_control: FrameControl(RESPONSE_FRAME_CONTROL),
             manufacturer_code: None,
-            sequence_number: frame.header.sequence_number,
-            command_identifier: CommandIdentifier::ReadAttributesResponse,
+            sequence_number,
+            command_identifier,
         },
-        payload: ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(records)),
+        payload: ZclFramePayload::GeneralCommand(payload),
     };
 
     let offset = &mut 0;
@@ -101,15 +213,7 @@ where
 pub struct AttributeServer<S>(pub S);
 
 impl<S: AttributeSource> ClusterRequestHandler for AttributeServer<S> {
-    fn handle(
-        &self,
-        _profile_id: u16,
-        cluster_id: u16,
-        _src_endpoint: u8,
-        _dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        handle_read_attributes(&self.0, cluster_id, asdu, out)
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        handle_read_attributes(&self.0, request.cluster_id, request.asdu, out)
     }
 }

--- a/zigbee-cluster-library/src/attributes.rs
+++ b/zigbee-cluster-library/src/attributes.rs
@@ -1,0 +1,115 @@
+//! Generic attribute access.
+//!
+//! See ZCL Section 2.5.1.
+//!
+//! A cluster server exposes its attributes by implementing [`AttributeSource`];
+//! [`handle_read_attributes`] then answers `Read Attributes` for it, so every
+//! cluster gets attribute reads without repeating the frame handling.
+
+use byte::BytesExt;
+use byte::TryRead;
+use heapless::Vec;
+use zigbee::zdo::ClusterRequestHandler;
+
+use crate::common::data_types::ZclDataType;
+use crate::frame::GeneralCommand;
+use crate::frame::ReadAttributeResponse;
+use crate::frame::Status;
+use crate::frame::ZclFrame;
+use crate::header::ZclHeader;
+use crate::header::command_identifier::CommandIdentifier;
+use crate::header::frame_control::FrameControl;
+use crate::payload::ZclFramePayload;
+
+/// Frame control for a global, server→client response with the default
+/// response disabled.
+pub(crate) const RESPONSE_FRAME_CONTROL: u8 = 0x18;
+
+// attribute records carried in one Read Attributes Response
+const MAX_RECORDS: usize = 16;
+
+/// A cluster server that can resolve attribute identifiers to values.
+pub trait AttributeSource {
+    /// Cluster this source answers for.
+    fn cluster_id(&self) -> u16;
+
+    /// Current value of `attribute_id`, or `None` when unsupported.
+    fn attribute(&self, attribute_id: u16) -> Option<ZclDataType<'_>>;
+}
+
+/// Answer a `Read Attributes` request (ZCL 2.5.1) from `source`.
+///
+/// Returns `None` for another cluster, another command, or an unparsable
+/// frame, leaving the caller free to try another handler. An unsupported
+/// attribute is reported per-record rather than failing the request.
+pub fn handle_read_attributes<S>(
+    source: &S,
+    cluster_id: u16,
+    asdu: &[u8],
+    out: &mut [u8],
+) -> Option<usize>
+where
+    S: AttributeSource + ?Sized,
+{
+    if cluster_id != source.cluster_id() {
+        return None;
+    }
+
+    let (frame, _) = ZclFrame::try_read(asdu, ()).ok()?;
+    let ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributes(requests)) = frame.payload
+    else {
+        return None;
+    };
+
+    let mut records: Vec<ReadAttributeResponse<'_>, MAX_RECORDS> = Vec::new();
+    for request in requests {
+        let record = source.attribute(request.attribute_id).map_or(
+            ReadAttributeResponse {
+                attribute_id: request.attribute_id,
+                status: Status::UnsupportedAttribute,
+                value: None,
+            },
+            |value| ReadAttributeResponse {
+                attribute_id: request.attribute_id,
+                status: Status::Success,
+                value: Some(value),
+            },
+        );
+        records.push(record).ok()?;
+    }
+
+    let response = ZclFrame {
+        header: ZclHeader {
+            frame_control: FrameControl(RESPONSE_FRAME_CONTROL),
+            manufacturer_code: None,
+            sequence_number: frame.header.sequence_number,
+            command_identifier: CommandIdentifier::ReadAttributesResponse,
+        },
+        payload: ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(records)),
+    };
+
+    let offset = &mut 0;
+    out.write_with(offset, response, ()).ok()?;
+    Some(*offset)
+}
+
+/// Adapts any [`AttributeSource`] into a read-only cluster server.
+///
+/// A cluster with its own commands implements [`ClusterRequestHandler`]
+/// directly and calls [`handle_read_attributes`] for the attribute half.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct AttributeServer<S>(pub S);
+
+impl<S: AttributeSource> ClusterRequestHandler for AttributeServer<S> {
+    fn handle(
+        &self,
+        _profile_id: u16,
+        cluster_id: u16,
+        _src_endpoint: u8,
+        _dst_endpoint: u8,
+        asdu: &[u8],
+        out: &mut [u8],
+    ) -> Option<usize> {
+        handle_read_attributes(&self.0, cluster_id, asdu, out)
+    }
+}

--- a/zigbee-cluster-library/src/basic.rs
+++ b/zigbee-cluster-library/src/basic.rs
@@ -7,23 +7,14 @@
 //! requests, which a coordinator issues during interview to resolve the device
 //! to its definition.
 
-use byte::BytesExt;
-use byte::TryRead;
-use heapless::Vec;
 use zigbee::zdo::ClusterRequestHandler;
 
+use crate::attributes::AttributeSource;
+use crate::attributes::handle_read_attributes;
 use crate::common::data_types::EnumN;
 use crate::common::data_types::UnsignedN;
 use crate::common::data_types::ZclDataType;
 use crate::common::data_types::ZclString;
-use crate::frame::GeneralCommand;
-use crate::frame::ReadAttributeResponse;
-use crate::frame::Status;
-use crate::frame::ZclFrame;
-use crate::header::ZclHeader;
-use crate::header::command_identifier::CommandIdentifier;
-use crate::header::frame_control::FrameControl;
-use crate::payload::ZclFramePayload;
 
 /// Cluster identifier (ZCL 3.2).
 pub const CLUSTER_ID: u16 = 0x0000;
@@ -46,10 +37,6 @@ pub mod attribute {
     pub const POWER_SOURCE: u16 = 0x0007;
 }
 
-/// Frame control for a global, server→client response with the default
-/// response disabled.
-const RESPONSE_FRAME_CONTROL: u8 = 0x18;
-
 /// Basic cluster server holding the device identity attribute values.
 #[derive(Debug, Clone, Copy)]
 pub struct BasicServer<'a> {
@@ -64,8 +51,12 @@ pub struct BasicServer<'a> {
     pub power_source: u8,
 }
 
-impl<'a> BasicServer<'a> {
-    fn attribute(&self, id: u16) -> Option<ZclDataType<'a>> {
+impl AttributeSource for BasicServer<'_> {
+    fn cluster_id(&self) -> u16 {
+        CLUSTER_ID
+    }
+
+    fn attribute(&self, id: u16) -> Option<ZclDataType<'_>> {
         Some(match id {
             attribute::ZCL_VERSION => ZclDataType::UnsignedInt(UnsignedN::Uint8(self.zcl_version)),
             attribute::APPLICATION_VERSION => {
@@ -97,49 +88,7 @@ impl ClusterRequestHandler for BasicServer<'_> {
         asdu: &[u8],
         out: &mut [u8],
     ) -> Option<usize> {
-        if cluster_id != CLUSTER_ID {
-            return None;
-        }
-
-        let (frame, _) = ZclFrame::try_read(asdu, ()).ok()?;
-        let ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributes(requests)) =
-            frame.payload
-        else {
-            return None;
-        };
-
-        let mut records: Vec<ReadAttributeResponse, 16> = Vec::new();
-        for request in requests {
-            let record = self.attribute(request.attribute_id).map_or(
-                ReadAttributeResponse {
-                    attribute_id: request.attribute_id,
-                    status: Status::UnsupportedAttribute,
-                    value: None,
-                },
-                |value| ReadAttributeResponse {
-                    attribute_id: request.attribute_id,
-                    status: Status::Success,
-                    value: Some(value),
-                },
-            );
-            records.push(record).ok()?;
-        }
-
-        let response = ZclFrame {
-            header: ZclHeader {
-                frame_control: FrameControl(RESPONSE_FRAME_CONTROL),
-                manufacturer_code: None,
-                sequence_number: frame.header.sequence_number,
-                command_identifier: CommandIdentifier::ReadAttributesResponse,
-            },
-            payload: ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(
-                records,
-            )),
-        };
-
-        let offset = &mut 0;
-        out.write_with(offset, response, ()).ok()?;
-        Some(*offset)
+        handle_read_attributes(self, cluster_id, asdu, out)
     }
 }
 
@@ -150,6 +99,10 @@ mod tests {
     use super::*;
     use crate::common::data_types::ZclString;
     use crate::frame::GeneralCommand;
+    use crate::frame::Status;
+    use crate::frame::ZclFrame;
+    use crate::header::command_identifier::CommandIdentifier;
+    use crate::payload::ZclFramePayload;
 
     const SERVER: BasicServer = BasicServer {
         zcl_version: 8,

--- a/zigbee-cluster-library/src/basic.rs
+++ b/zigbee-cluster-library/src/basic.rs
@@ -7,6 +7,7 @@
 //! requests, which a coordinator issues during interview to resolve the device
 //! to its definition.
 
+use zigbee::zdo::ClusterRequest;
 use zigbee::zdo::ClusterRequestHandler;
 
 use crate::attributes::AttributeSource;
@@ -79,16 +80,8 @@ impl AttributeSource for BasicServer<'_> {
 }
 
 impl ClusterRequestHandler for BasicServer<'_> {
-    fn handle(
-        &self,
-        _profile_id: u16,
-        cluster_id: u16,
-        _src_endpoint: u8,
-        _dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        handle_read_attributes(self, cluster_id, asdu, out)
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        handle_read_attributes(self, request.cluster_id, request.asdu, out)
     }
 }
 
@@ -114,11 +107,22 @@ mod tests {
         power_source: 0x03,
     };
 
+    fn request(cluster_id: u16, asdu: &[u8]) -> ClusterRequest<'_> {
+        ClusterRequest {
+            profile_id: 0x0104,
+            cluster_id,
+            src_endpoint: 1,
+            dst_endpoint: 1,
+            unicast: true,
+            asdu,
+        }
+    }
+
     #[test]
     fn read_manufacturer_model_and_unknown() {
         // ZCL Read Attributes (global cmd 0x00, client->server) for
         // ManufacturerName (0x0004), ModelIdentifier (0x0005), unknown (0x9999)
-        let request = [
+        let asdu = [
             0x00, 0x2a, 0x00, // frame control, seq, command id (ReadAttributes)
             0x04, 0x00, // 0x0004
             0x05, 0x00, // 0x0005
@@ -127,7 +131,7 @@ mod tests {
 
         let mut out = [0u8; 128];
         let len = SERVER
-            .handle(0x0104, CLUSTER_ID, 1, 1, &request, &mut out)
+            .handle(&request(CLUSTER_ID, &asdu), &mut out)
             .expect("basic read handled");
 
         let (frame, _) = ZclFrame::try_read(&out[..len], ()).unwrap();
@@ -164,11 +168,8 @@ mod tests {
 
     #[test]
     fn ignores_other_clusters() {
-        let request = [0x00, 0x01, 0x00, 0x00, 0x00];
+        let asdu = [0x00, 0x01, 0x00, 0x00, 0x00];
         let mut out = [0u8; 32];
-        assert_eq!(
-            SERVER.handle(0x0104, 0x0402, 1, 1, &request, &mut out),
-            None
-        );
+        assert_eq!(SERVER.handle(&request(0x0402, &asdu), &mut out), None);
     }
 }

--- a/zigbee-cluster-library/src/identify.rs
+++ b/zigbee-cluster-library/src/identify.rs
@@ -1,0 +1,251 @@
+//! Identify Cluster
+//!
+//! See ZCL Section 3.5
+//!
+//! Lets a commissioning tool ask a device to make itself physically
+//! identifiable for a number of seconds. [`IdentifyServer`] owns the
+//! countdown; the application decides what identifying looks like by polling
+//! [`IdentifyServer::is_identifying`].
+
+use core::sync::atomic::AtomicU16;
+use core::sync::atomic::Ordering;
+
+use byte::BytesExt;
+use byte::TryRead;
+use zigbee::zdo::ClusterRequestHandler;
+
+use crate::attributes::AttributeSource;
+use crate::attributes::handle_read_attributes;
+use crate::common::data_types::UnsignedN;
+use crate::common::data_types::ZclDataType;
+use crate::frame::ZclFrame;
+use crate::header::ZclHeader;
+use crate::header::command_identifier::CommandIdentifier;
+use crate::header::frame_control::FrameControl;
+use crate::payload::ZclFramePayload;
+use crate::types::ids::CommandId;
+
+/// Cluster identifier (ZCL 3.5).
+pub const CLUSTER_ID: u16 = 0x0003;
+
+/// Attribute identifiers (ZCL 3.5.2.2).
+pub mod attribute {
+    /// `IdentifyTime` (`uint16`), seconds remaining in the identify state.
+    pub const IDENTIFY_TIME: u16 = 0x0000;
+}
+
+/// Cluster-specific command identifiers (ZCL 3.5.2.3 / 3.5.2.4).
+pub mod command {
+    /// Received: start identifying for the payload's duration.
+    pub const IDENTIFY: u8 = 0x00;
+    /// Received: ask whether the device is currently identifying.
+    pub const IDENTIFY_QUERY: u8 = 0x01;
+    /// Generated: answer to [`IDENTIFY_QUERY`], carrying the time remaining.
+    pub const IDENTIFY_QUERY_RESPONSE: u8 = 0x00;
+}
+
+// cluster-specific, server->client, default response disabled
+const CLUSTER_RESPONSE_FRAME_CONTROL: u8 = 0x19;
+
+/// Identify cluster server.
+///
+/// The countdown is not automatic: call [`IdentifyServer::tick`] once a
+/// second.
+#[derive(Debug, Default)]
+pub struct IdentifyServer {
+    identify_time: AtomicU16,
+}
+
+impl IdentifyServer {
+    /// A server that starts out not identifying.
+    pub const fn new() -> Self {
+        Self {
+            identify_time: AtomicU16::new(0),
+        }
+    }
+
+    /// Seconds remaining in the identify state; `0` means not identifying.
+    pub fn identify_time(&self) -> u16 {
+        self.identify_time.load(Ordering::Relaxed)
+    }
+
+    /// Enter (or leave, with `0`) the identify state for `seconds`.
+    pub fn set_identify_time(&self, seconds: u16) {
+        self.identify_time.store(seconds, Ordering::Relaxed);
+    }
+
+    /// Whether the device should currently be making itself identifiable.
+    pub fn is_identifying(&self) -> bool {
+        self.identify_time() != 0
+    }
+
+    /// Advance the countdown by `seconds`, saturating at zero, and report the
+    /// time left.
+    pub fn tick(&self, seconds: u16) -> u16 {
+        let remaining = self.identify_time().saturating_sub(seconds);
+        self.set_identify_time(remaining);
+        remaining
+    }
+}
+
+impl AttributeSource for IdentifyServer {
+    fn cluster_id(&self) -> u16 {
+        CLUSTER_ID
+    }
+
+    fn attribute(&self, id: u16) -> Option<ZclDataType<'_>> {
+        match id {
+            attribute::IDENTIFY_TIME => Some(ZclDataType::UnsignedInt(UnsignedN::Uint16(
+                self.identify_time(),
+            ))),
+            _ => None,
+        }
+    }
+}
+
+impl ClusterRequestHandler for IdentifyServer {
+    fn handle(
+        &self,
+        _profile_id: u16,
+        cluster_id: u16,
+        _src_endpoint: u8,
+        _dst_endpoint: u8,
+        asdu: &[u8],
+        out: &mut [u8],
+    ) -> Option<usize> {
+        if cluster_id != CLUSTER_ID {
+            return None;
+        }
+
+        let (frame, _) = ZclFrame::try_read(asdu, ()).ok()?;
+        let ZclFramePayload::ClusterSpecificCommand { command_id, data } = frame.payload else {
+            return handle_read_attributes(self, cluster_id, asdu, out);
+        };
+
+        match command_id.0 {
+            command::IDENTIFY => {
+                // payload: IdentifyTime, uint16 (ZCL 3.5.2.3.1.1)
+                let seconds = u16::from_le_bytes(data.get(..2)?.try_into().ok()?);
+                self.set_identify_time(seconds);
+                None
+            }
+            // answered only while identifying (ZCL 3.5.2.4.1)
+            command::IDENTIFY_QUERY if self.is_identifying() => {
+                let remaining = self.identify_time().to_le_bytes();
+                let response = ZclFrame {
+                    header: ZclHeader {
+                        frame_control: FrameControl(CLUSTER_RESPONSE_FRAME_CONTROL),
+                        manufacturer_code: None,
+                        sequence_number: frame.header.sequence_number,
+                        command_identifier: CommandIdentifier::from_bits(
+                            command::IDENTIFY_QUERY_RESPONSE,
+                        ),
+                    },
+                    payload: ZclFramePayload::ClusterSpecificCommand {
+                        command_id: CommandId(command::IDENTIFY_QUERY_RESPONSE),
+                        data: &remaining,
+                    },
+                };
+
+                let offset = &mut 0;
+                out.write_with(offset, response, ()).ok()?;
+                Some(*offset)
+            }
+            _ => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::frame::GeneralCommand;
+    use crate::frame::Status;
+
+    // cluster-specific, client->server, Identify for 30 s
+    const IDENTIFY_30S: [u8; 5] = [0x01, 0x2a, 0x00, 0x1e, 0x00];
+    // cluster-specific, client->server, Identify Query
+    const IDENTIFY_QUERY: [u8; 3] = [0x01, 0x2b, 0x01];
+
+    #[test]
+    fn identify_command_sets_the_countdown() {
+        let server = IdentifyServer::new();
+        let mut out = [0u8; 32];
+
+        assert!(!server.is_identifying());
+        // the command produces no reply, only state
+        assert_eq!(
+            server.handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_30S, &mut out),
+            None
+        );
+        assert_eq!(server.identify_time(), 30);
+        assert!(server.is_identifying());
+    }
+
+    #[test]
+    fn identify_query_answers_only_while_identifying() {
+        let server = IdentifyServer::new();
+        let mut out = [0u8; 32];
+
+        // not identifying: silence
+        assert_eq!(
+            server.handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_QUERY, &mut out),
+            None
+        );
+
+        server.set_identify_time(30);
+        let n = server
+            .handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_QUERY, &mut out)
+            .expect("query answered while identifying");
+        // frame control 0x19 (cluster-specific, s->c, no default response),
+        // seq echoed, command 0x00, then IdentifyTime as uint16
+        assert_eq!(&out[..n], &[0x19, 0x2b, 0x00, 0x1e, 0x00]);
+    }
+
+    #[test]
+    fn tick_counts_down_and_saturates() {
+        let server = IdentifyServer::new();
+        server.set_identify_time(3);
+        assert_eq!(server.tick(1), 2);
+        assert_eq!(server.tick(5), 0);
+        assert!(!server.is_identifying());
+        // already at zero, stays there
+        assert_eq!(server.tick(1), 0);
+    }
+
+    #[test]
+    fn reads_identify_time_attribute() {
+        let server = IdentifyServer::new();
+        server.set_identify_time(0x1234);
+        // global Read Attributes for IdentifyTime (0x0000)
+        let request = [0x00, 0x07, 0x00, 0x00, 0x00];
+        let mut out = [0u8; 32];
+        let n = server
+            .handle(0x0104, CLUSTER_ID, 1, 1, &request, &mut out)
+            .expect("attribute read handled");
+
+        let (frame, _) = ZclFrame::try_read(&out[..n], ()).unwrap();
+        let ZclFramePayload::GeneralCommand(GeneralCommand::ReadAttributesResponse(records)) =
+            frame.payload
+        else {
+            panic!("expected ReadAttributesResponse");
+        };
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].attribute_id, attribute::IDENTIFY_TIME);
+        assert_eq!(records[0].status, Status::Success);
+        assert_eq!(
+            records[0].value,
+            Some(ZclDataType::UnsignedInt(UnsignedN::Uint16(0x1234)))
+        );
+    }
+
+    #[test]
+    fn ignores_other_clusters() {
+        let server = IdentifyServer::new();
+        let mut out = [0u8; 32];
+        assert_eq!(
+            server.handle(0x0104, 0x0402, 1, 1, &IDENTIFY_30S, &mut out),
+            None
+        );
+    }
+}

--- a/zigbee-cluster-library/src/identify.rs
+++ b/zigbee-cluster-library/src/identify.rs
@@ -12,12 +12,17 @@ use core::sync::atomic::Ordering;
 
 use byte::BytesExt;
 use byte::TryRead;
+use zigbee::zdo::ClusterRequest;
 use zigbee::zdo::ClusterRequestHandler;
 
+use crate::attributes::AttributeSink;
 use crate::attributes::AttributeSource;
+use crate::attributes::default_response;
 use crate::attributes::handle_read_attributes;
+use crate::attributes::handle_write_attributes;
 use crate::common::data_types::UnsignedN;
 use crate::common::data_types::ZclDataType;
+use crate::frame::Status;
 use crate::frame::ZclFrame;
 use crate::header::ZclHeader;
 use crate::header::command_identifier::CommandIdentifier;
@@ -103,31 +108,52 @@ impl AttributeSource for IdentifyServer {
     }
 }
 
+/// `IdentifyTime` is writable (ZCL 3.5.2.2): a write starts or stops the
+/// identification procedure just like the Identify command does.
+impl AttributeSink for IdentifyServer {
+    fn set_attribute(&self, id: u16, value: &ZclDataType<'_>) -> Status {
+        if id != attribute::IDENTIFY_TIME {
+            return Status::UnsupportedAttribute;
+        }
+        let ZclDataType::UnsignedInt(UnsignedN::Uint16(seconds)) = value else {
+            return Status::InvalidDataType;
+        };
+        self.set_identify_time(*seconds);
+        Status::Success
+    }
+}
+
 impl ClusterRequestHandler for IdentifyServer {
-    fn handle(
-        &self,
-        _profile_id: u16,
-        cluster_id: u16,
-        _src_endpoint: u8,
-        _dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        if cluster_id != CLUSTER_ID {
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        if request.cluster_id != CLUSTER_ID {
             return None;
         }
 
-        let (frame, _) = ZclFrame::try_read(asdu, ()).ok()?;
+        let (frame, _) = ZclFrame::try_read(request.asdu, ()).ok()?;
         let ZclFramePayload::ClusterSpecificCommand { command_id, data } = frame.payload else {
-            return handle_read_attributes(self, cluster_id, asdu, out);
+            return handle_read_attributes(self, request.cluster_id, request.asdu, out)
+                .or_else(|| handle_write_attributes(self, request.cluster_id, request.asdu, out));
         };
 
-        match command_id.0 {
+        // a command answered by a cluster response draws no Default Response
+        // (ZCL 2.5.12.2)
+        let status = match command_id.0 {
             command::IDENTIFY => {
                 // payload: IdentifyTime, uint16 (ZCL 3.5.2.3.1.1)
-                let seconds = u16::from_le_bytes(data.get(..2)?.try_into().ok()?);
+                let Some(seconds) = data
+                    .get(..2)
+                    .and_then(|bytes| bytes.try_into().ok())
+                    .map(u16::from_le_bytes)
+                else {
+                    return default_response(
+                        &frame.header,
+                        request.unicast,
+                        Status::MalformedCommand,
+                        out,
+                    );
+                };
                 self.set_identify_time(seconds);
-                None
+                Status::Success
             }
             // answered only while identifying (ZCL 3.5.2.4.1)
             command::IDENTIFY_QUERY if self.is_identifying() => {
@@ -149,10 +175,13 @@ impl ClusterRequestHandler for IdentifyServer {
 
                 let offset = &mut 0;
                 out.write_with(offset, response, ()).ok()?;
-                Some(*offset)
+                return Some(*offset);
             }
-            _ => None,
-        }
+            command::IDENTIFY_QUERY => Status::Success,
+            _ => Status::UnsupCommand,
+        };
+
+        default_response(&frame.header, request.unicast, status, out)
     }
 }
 
@@ -160,12 +189,24 @@ impl ClusterRequestHandler for IdentifyServer {
 mod tests {
     use super::*;
     use crate::frame::GeneralCommand;
-    use crate::frame::Status;
 
     // cluster-specific, client->server, Identify for 30 s
     const IDENTIFY_30S: [u8; 5] = [0x01, 0x2a, 0x00, 0x1e, 0x00];
+    // same, with the default response disabled
+    const IDENTIFY_30S_NO_DEFAULT_RSP: [u8; 5] = [0x11, 0x2a, 0x00, 0x1e, 0x00];
     // cluster-specific, client->server, Identify Query
     const IDENTIFY_QUERY: [u8; 3] = [0x01, 0x2b, 0x01];
+
+    fn request(asdu: &[u8]) -> ClusterRequest<'_> {
+        ClusterRequest {
+            profile_id: 0x0104,
+            cluster_id: CLUSTER_ID,
+            src_endpoint: 1,
+            dst_endpoint: 1,
+            unicast: true,
+            asdu,
+        }
+    }
 
     #[test]
     fn identify_command_sets_the_countdown() {
@@ -173,13 +214,33 @@ mod tests {
         let mut out = [0u8; 32];
 
         assert!(!server.is_identifying());
-        // the command produces no reply, only state
+        let n = server
+            .handle(&request(&IDENTIFY_30S), &mut out)
+            .expect("default response for a unicast Identify");
+        // global s->c frame, seq echoed, DefaultResponse (0x0b) for command
+        // 0x00 with status SUCCESS
+        assert_eq!(&out[..n], &[0x18, 0x2a, 0x0b, 0x00, 0x00]);
+        assert_eq!(server.identify_time(), 30);
+        assert!(server.is_identifying());
+    }
+
+    #[test]
+    fn identify_command_honors_disabled_default_response() {
+        let server = IdentifyServer::new();
+        let mut out = [0u8; 32];
+
         assert_eq!(
-            server.handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_30S, &mut out),
+            server.handle(&request(&IDENTIFY_30S_NO_DEFAULT_RSP), &mut out),
             None
         );
         assert_eq!(server.identify_time(), 30);
-        assert!(server.is_identifying());
+
+        // a broadcast never draws a default response either (ZCL 2.5.12.2)
+        let broadcast = ClusterRequest {
+            unicast: false,
+            ..request(&IDENTIFY_30S)
+        };
+        assert_eq!(server.handle(&broadcast, &mut out), None);
     }
 
     #[test]
@@ -187,19 +248,45 @@ mod tests {
         let server = IdentifyServer::new();
         let mut out = [0u8; 32];
 
-        // not identifying: silence
-        assert_eq!(
-            server.handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_QUERY, &mut out),
-            None
-        );
+        // not identifying: no query response, only a default response
+        let n = server
+            .handle(&request(&IDENTIFY_QUERY), &mut out)
+            .expect("default response while not identifying");
+        assert_eq!(&out[..n], &[0x18, 0x2b, 0x0b, 0x01, 0x00]);
 
         server.set_identify_time(30);
         let n = server
-            .handle(0x0104, CLUSTER_ID, 1, 1, &IDENTIFY_QUERY, &mut out)
+            .handle(&request(&IDENTIFY_QUERY), &mut out)
             .expect("query answered while identifying");
         // frame control 0x19 (cluster-specific, s->c, no default response),
         // seq echoed, command 0x00, then IdentifyTime as uint16
         assert_eq!(&out[..n], &[0x19, 0x2b, 0x00, 0x1e, 0x00]);
+    }
+
+    #[test]
+    fn unsupported_command_reports_unsup_command() {
+        let server = IdentifyServer::new();
+        let mut out = [0u8; 32];
+        // Trigger Effect (0x40) is optional and not implemented
+        let asdu = [0x01, 0x2c, 0x40, 0x00, 0x00];
+        let n = server
+            .handle(&request(&asdu), &mut out)
+            .expect("default response for an unknown command");
+        assert_eq!(&out[..n], &[0x18, 0x2c, 0x0b, 0x40, 0x81]);
+    }
+
+    #[test]
+    fn writes_identify_time_attribute() {
+        let server = IdentifyServer::new();
+        // global Write Attributes: IdentifyTime (0x0000), uint16 (0x21), 30 s
+        let asdu = [0x00, 0x0a, 0x02, 0x00, 0x00, 0x21, 0x1e, 0x00];
+        let mut out = [0u8; 32];
+        let n = server
+            .handle(&request(&asdu), &mut out)
+            .expect("attribute write handled");
+        // header + single SUCCESS record (ZCL 2.5.4.1.2)
+        assert_eq!(&out[..n], &[0x18, 0x0a, 0x04, 0x00]);
+        assert_eq!(server.identify_time(), 30);
     }
 
     #[test]
@@ -218,10 +305,10 @@ mod tests {
         let server = IdentifyServer::new();
         server.set_identify_time(0x1234);
         // global Read Attributes for IdentifyTime (0x0000)
-        let request = [0x00, 0x07, 0x00, 0x00, 0x00];
+        let asdu = [0x00, 0x07, 0x00, 0x00, 0x00];
         let mut out = [0u8; 32];
         let n = server
-            .handle(0x0104, CLUSTER_ID, 1, 1, &request, &mut out)
+            .handle(&request(&asdu), &mut out)
             .expect("attribute read handled");
 
         let (frame, _) = ZclFrame::try_read(&out[..n], ()).unwrap();
@@ -243,9 +330,10 @@ mod tests {
     fn ignores_other_clusters() {
         let server = IdentifyServer::new();
         let mut out = [0u8; 32];
-        assert_eq!(
-            server.handle(0x0104, 0x0402, 1, 1, &IDENTIFY_30S, &mut out),
-            None
-        );
+        let other = ClusterRequest {
+            cluster_id: 0x0402,
+            ..request(&IDENTIFY_30S)
+        };
+        assert_eq!(server.handle(&other, &mut out), None);
     }
 }

--- a/zigbee-cluster-library/src/lib.rs
+++ b/zigbee-cluster-library/src/lib.rs
@@ -41,8 +41,10 @@ macro_rules! bad_input {
     };
 }
 
+pub mod attributes;
 pub mod basic;
 pub mod common;
+pub mod identify;
 pub mod profile;
 pub mod types;
 

--- a/zigbee-cluster-library/src/reporting.rs
+++ b/zigbee-cluster-library/src/reporting.rs
@@ -8,6 +8,7 @@
 
 use byte::BytesExt;
 use byte::TryRead;
+use zigbee::zdo::ClusterRequest;
 use zigbee::zdo::ClusterRequestHandler;
 
 use crate::attributes::RESPONSE_FRAME_CONTROL;
@@ -26,18 +27,10 @@ use crate::header::frame_control::FrameControl;
 pub struct ConfigureReportingServer;
 
 impl ClusterRequestHandler for ConfigureReportingServer {
-    fn handle(
-        &self,
-        _profile_id: u16,
-        _cluster_id: u16,
-        _src_endpoint: u8,
-        _dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
         // only the header is needed to ack; the configuration records carry
         // variable-length reportable-change fields we do not act on
-        let (header, _) = ZclHeader::try_read(asdu, ()).ok()?;
+        let (header, _) = ZclHeader::try_read(request.asdu, ()).ok()?;
         if header.command_identifier != CommandIdentifier::ConfigureReporting {
             return None;
         }
@@ -61,18 +54,29 @@ impl ClusterRequestHandler for ConfigureReportingServer {
 mod tests {
     use super::*;
 
+    fn request(cluster_id: u16, asdu: &[u8]) -> ClusterRequest<'_> {
+        ClusterRequest {
+            profile_id: 0x0104,
+            cluster_id,
+            src_endpoint: 1,
+            dst_endpoint: 1,
+            unicast: true,
+            asdu,
+        }
+    }
+
     #[test]
     fn acks_configure_reporting_with_success() {
         // Configure Reporting (global cmd 0x06) for temperature MeasuredValue;
         // the trailing configuration record is intentionally ignored
-        let request = [
+        let asdu = [
             0x00, 0x2b, 0x06, // frame control (global, c->s), seq, ConfigureReporting
             0x00, 0x00, 0x00, // direction, attribute id 0x0000
             0x29, 0x1e, 0x00, 0x58, 0x02, 0x64, 0x00, // type int16, intervals, change
         ];
         let mut out = [0u8; 16];
         let n = ConfigureReportingServer
-            .handle(0x0104, 0x0402, 1, 1, &request, &mut out)
+            .handle(&request(0x0402, &asdu), &mut out)
             .expect("configure reporting handled");
         // header (0x18, seq 0x2b, ConfigureReportingResponse 0x07) + status SUCCESS
         assert_eq!(&out[..n], &[0x18, 0x2b, 0x07, 0x00]);
@@ -81,10 +85,10 @@ mod tests {
     #[test]
     fn ignores_other_commands() {
         // Read Attributes (0x00) is not ours
-        let request = [0x00, 0x01, 0x00, 0x04, 0x00];
+        let asdu = [0x00, 0x01, 0x00, 0x04, 0x00];
         let mut out = [0u8; 16];
         assert_eq!(
-            ConfigureReportingServer.handle(0x0104, 0x0000, 1, 1, &request, &mut out),
+            ConfigureReportingServer.handle(&request(0x0000, &asdu), &mut out),
             None
         );
     }

--- a/zigbee-cluster-library/src/reporting.rs
+++ b/zigbee-cluster-library/src/reporting.rs
@@ -10,14 +10,11 @@ use byte::BytesExt;
 use byte::TryRead;
 use zigbee::zdo::ClusterRequestHandler;
 
+use crate::attributes::RESPONSE_FRAME_CONTROL;
 use crate::frame::Status;
 use crate::header::ZclHeader;
 use crate::header::command_identifier::CommandIdentifier;
 use crate::header::frame_control::FrameControl;
-
-/// Frame control for a global, server→client response with the default
-/// response disabled.
-const RESPONSE_FRAME_CONTROL: u8 = 0x18;
 
 /// Answers ZCL `Configure Reporting` requests with a blanket success.
 ///

--- a/zigbee/src/apl/descriptors/node_power_descriptor.rs
+++ b/zigbee/src/apl/descriptors/node_power_descriptor.rs
@@ -12,6 +12,9 @@ use zigbee_macros::impl_byte;
 
 const NODE_POWER_DESCRIPTOR_SIZE: usize = 2;
 
+// every node power descriptor field is 4 bits wide
+const NIBBLE: u8 = 0b1111;
+
 #[derive(Debug)]
 pub struct NodePowerDescriptor<'a> {
     bytes: &'a [u8],
@@ -22,27 +25,18 @@ impl<'a> TryRead<'a, byte::ctx::Endian> for NodePowerDescriptor<'a> {
         let offset = &mut 0;
 
         let byte: u8 = bytes.read_with(offset, endian)?;
-        let available_power_sources = AvailablePowerSources(byte >> 4);
+        let available_power_sources = byte >> 4;
 
         let byte: u8 = bytes.read_with(offset, endian)?;
-        let current_power_source = CurrentPowerSource::try_read(&[byte & 0b1111], ())
-            .unwrap()
-            .0;
+        let current_power_source = PowerSource::try_read(&[byte & NIBBLE], ()).unwrap().0;
 
-        let power_source = match current_power_source {
-            CurrentPowerSource::ConstantMainPower => AvailablePowerSourcesFlag::ConstantMainPower,
-            CurrentPowerSource::RechargeableBattery => {
-                AvailablePowerSourcesFlag::RechargeableBattery
-            }
-            CurrentPowerSource::DisposableBattery => AvailablePowerSourcesFlag::DisposableBattery,
-            CurrentPowerSource::Reserved(_) => {
-                return Err(byte::Error::BadInput {
-                    err: "CurrentPowerSourceNotAvailable: No curent power source set",
-                });
-            }
-        };
+        if let PowerSource::Reserved(_) = current_power_source {
+            return Err(byte::Error::BadInput {
+                err: "CurrentPowerSourceNotAvailable: No curent power source set",
+            });
+        }
 
-        if available_power_sources.is_set(power_source) {
+        if available_power_sources & current_power_source.bits() != 0 {
             Ok((NodePowerDescriptor { bytes }, *offset))
         } else {
             Err(byte::Error::BadInput {
@@ -54,17 +48,18 @@ impl<'a> TryRead<'a, byte::ctx::Endian> for NodePowerDescriptor<'a> {
 
 impl NodePowerDescriptor<'_> {
     fn current_power_mode(&self) -> CurrentPowerMode {
-        CurrentPowerMode::try_read(&[self.bytes[0] & 0b1111], ())
+        CurrentPowerMode::try_read(&[self.bytes[0] & NIBBLE], ())
             .unwrap()
             .0
     }
 
-    fn available_power_sources(&self) -> AvailablePowerSources {
-        AvailablePowerSources(self.bytes[0] >> 4)
+    /// Whether the node declares `power_source` as available (2.3.2.4.2).
+    pub fn supports(&self, power_source: PowerSource) -> bool {
+        (self.bytes[0] >> 4) & power_source.bits() != 0
     }
 
-    fn current_power_source(&self) -> CurrentPowerSource {
-        CurrentPowerSource::try_read(&[self.bytes[1] & 0b1111], ())
+    fn current_power_source(&self) -> PowerSource {
+        PowerSource::try_read(&[self.bytes[1] & NIBBLE], ())
             .unwrap()
             .0
     }
@@ -78,7 +73,7 @@ impl NodePowerDescriptor<'_> {
 
 impl_byte! {
     #[tag(u8)]
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     /// Current power mode field (2.3.2.4.1).
     pub enum CurrentPowerMode {
         /// Synchronized with the receiver-on-when-idle subfield of the node descriptor.
@@ -92,39 +87,59 @@ impl_byte! {
     }
 }
 
-/// Available power sources field (2.3.2.4.2).
-pub struct AvailablePowerSources(u8);
-
-#[repr(u8)]
-#[derive(Clone, Copy, Eq, Hash, PartialEq)]
-pub enum AvailablePowerSourcesFlag {
-    ConstantMainPower = 0,
-    RechargeableBattery = 1,
-    DisposableBattery = 2,
-}
-
-impl AvailablePowerSources {
-    fn is_set(&self, power_source: AvailablePowerSourcesFlag) -> bool {
-        (self.0 & (1 << power_source as u8)) != 0
+impl CurrentPowerMode {
+    /// The 4-bit field value.
+    pub const fn bits(self) -> u8 {
+        match self {
+            Self::Synchronized => 0b0000,
+            Self::Periodically => 0b0001,
+            Self::Stimulated => 0b0010,
+            Self::Reserved(bits) => bits & NIBBLE,
+        }
     }
 }
 
 impl_byte! {
     #[tag(u8)]
-    #[derive(Debug, PartialEq, Eq)]
-    /// Current power source field (2.3.2.4.3).
-    pub enum CurrentPowerSource {
-        ConstantMainPower = 0b000,
-        RechargeableBattery = 0b010,
-        DisposableBattery = 0b100,
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
+    /// A power source of the node, as its bit in the available power sources
+    /// (2.3.2.4.2) and current power source (2.3.2.4.3) fields, which share a
+    /// bit assignment.
+    pub enum PowerSource {
+        ConstantMainPower = 0b0001,
+        RechargeableBattery = 0b0010,
+        DisposableBattery = 0b0100,
         #[fallback = true]
         Reserved(u8),
     }
 }
 
+impl PowerSource {
+    /// The 4-bit field value with this source's bit set.
+    pub const fn bits(self) -> u8 {
+        match self {
+            Self::ConstantMainPower => 0b0001,
+            Self::RechargeableBattery => 0b0010,
+            Self::DisposableBattery => 0b0100,
+            Self::Reserved(bits) => bits & NIBBLE,
+        }
+    }
+
+    /// The 4-bit field value covering every source in `sources`.
+    pub const fn bitmap(sources: &[Self]) -> u8 {
+        let mut bits = 0;
+        let mut i = 0;
+        while i < sources.len() {
+            bits |= sources[i].bits();
+            i += 1;
+        }
+        bits
+    }
+}
+
 impl_byte! {
     #[tag(u8)]
-    #[derive(Debug, PartialEq, Eq)]
+    #[derive(Debug, Clone, Copy, PartialEq, Eq)]
     /// Current power source level field (2.3.2.4.4).
     pub enum CurrentPowerSourceLevel {
         Critical = 0b0000,
@@ -133,6 +148,19 @@ impl_byte! {
         Full = 0b1100,
         #[fallback = true]
         Reserved(u8),
+    }
+}
+
+impl CurrentPowerSourceLevel {
+    /// The 4-bit field value.
+    pub const fn bits(self) -> u8 {
+        match self {
+            Self::Critical => 0b0000,
+            Self::OneThird => 0b0100,
+            Self::TwoThirds => 0b1000,
+            Self::Full => 0b1100,
+            Self::Reserved(bits) => bits & NIBBLE,
+        }
     }
 }
 
@@ -152,24 +180,12 @@ mod tests {
             node_power_descriptor.current_power_mode(),
             CurrentPowerMode::Synchronized
         );
-        assert!(
-            node_power_descriptor
-                .available_power_sources()
-                .is_set(AvailablePowerSourcesFlag::DisposableBattery)
-        );
-        assert!(
-            node_power_descriptor
-                .available_power_sources()
-                .is_set(AvailablePowerSourcesFlag::ConstantMainPower)
-        );
-        assert!(
-            !node_power_descriptor
-                .available_power_sources()
-                .is_set(AvailablePowerSourcesFlag::RechargeableBattery)
-        );
+        assert!(node_power_descriptor.supports(PowerSource::DisposableBattery));
+        assert!(node_power_descriptor.supports(PowerSource::ConstantMainPower));
+        assert!(!node_power_descriptor.supports(PowerSource::RechargeableBattery));
         assert_eq!(
             node_power_descriptor.current_power_source(),
-            CurrentPowerSource::DisposableBattery
+            PowerSource::DisposableBattery
         );
         assert_eq!(
             node_power_descriptor.current_power_source_level(),

--- a/zigbee/src/apl/descriptors/simple_descriptor.rs
+++ b/zigbee/src/apl/descriptors/simple_descriptor.rs
@@ -56,10 +56,10 @@ mod tests {
             APPLICATION_INPUT_CLUSTER_COUNT
         );
         assert!(!simple_descriptor.application_input_cluster_list.is_empty());
-        for i in 0..APPLICATION_INPUT_CLUSTER_COUNT as usize {
+        for i in 0..APPLICATION_INPUT_CLUSTER_COUNT {
             assert_eq!(
-                simple_descriptor.application_input_cluster_list[i],
-                (i + 1) as u8
+                simple_descriptor.application_input_cluster_list[i as usize],
+                (i + 1)
             );
         }
         assert_eq!(
@@ -67,10 +67,10 @@ mod tests {
             APPLICATION_OUTPUT_CLUSTER_COUNT
         );
         assert!(!simple_descriptor.application_output_cluster_list.is_empty());
-        for i in 0..APPLICATION_OUTPUT_CLUSTER_COUNT as usize {
+        for i in 0..APPLICATION_OUTPUT_CLUSTER_COUNT {
             assert_eq!(
-                simple_descriptor.application_output_cluster_list[i],
-                (i + 2) as u8
+                simple_descriptor.application_output_cluster_list[i as usize],
+                (i + 2)
             );
         }
     }
@@ -93,10 +93,10 @@ mod tests {
             APPLICATION_INPUT_CLUSTER_COUNT
         );
         assert!(!simple_descriptor.application_input_cluster_list.is_empty());
-        for i in 0..APPLICATION_INPUT_CLUSTER_COUNT as usize {
+        for i in 0..APPLICATION_INPUT_CLUSTER_COUNT {
             assert_eq!(
-                simple_descriptor.application_input_cluster_list[i],
-                (i + 1) as u8
+                simple_descriptor.application_input_cluster_list[i as usize],
+                (i + 1)
             );
         }
         assert_eq!(simple_descriptor.application_output_cluster_count, 0);
@@ -123,10 +123,10 @@ mod tests {
             APPLICATION_OUTPUT_CLUSTER_COUNT
         );
         assert!(!simple_descriptor.application_output_cluster_list.is_empty());
-        for i in 0..APPLICATION_OUTPUT_CLUSTER_COUNT as usize {
+        for i in 0..APPLICATION_OUTPUT_CLUSTER_COUNT {
             assert_eq!(
-                simple_descriptor.application_output_cluster_list[i],
-                (i + 2) as u8
+                simple_descriptor.application_output_cluster_list[i as usize],
+                (i + 2)
             );
         }
     }

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -282,7 +282,9 @@ impl Apsme {
         mut nwk_data: crate::nwk::frame::DataFrame<'a>,
     ) -> Result<Option<ApsdeSapIndication<'a>>, NetworkError> {
         let src_short = nwk_data.header.source.0;
-        let local_addr = *nlme.nib().network_address();
+        // the NWK destination, not our own address: the higher layer answers a
+        // broadcast differently from a unicast (2.4.4.2.7)
+        let dst_short = nwk_data.header.destination.0;
         let aps_bytes = nwk_data.payload;
 
         let offset = &mut 0;
@@ -340,7 +342,7 @@ impl Apsme {
 
         Ok(Some(ApsdeSapIndication {
             dst_addr_mode: DstAddrMode::Network,
-            dst_address: Address::Network(local_addr),
+            dst_address: Address::Network(dst_short),
             dst_endpoint: header.destination_endpoint.unwrap_or(0),
             src_addr_mode: SrcAddrMode::Short,
             src_address: Address::Network(src_short),

--- a/zigbee/src/lib.rs
+++ b/zigbee/src/lib.rs
@@ -78,4 +78,7 @@ pub mod zdp;
 pub mod zdo;
 
 pub use apl::descriptors::node_descriptor::LogicalType;
+pub use apl::descriptors::node_power_descriptor::CurrentPowerMode;
+pub use apl::descriptors::node_power_descriptor::CurrentPowerSourceLevel;
+pub use apl::descriptors::node_power_descriptor::PowerSource;
 pub use zdo::config::Config;

--- a/zigbee/src/zdo/descriptor.rs
+++ b/zigbee/src/zdo/descriptor.rs
@@ -438,8 +438,11 @@ impl MatchDescReq<'_> {
 
 fn cluster_ids(bytes: &[u8]) -> impl Iterator<Item = u16> + '_ {
     bytes
-        .chunks_exact(2)
-        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+        .as_chunks::<2>()
+        .0
+        .iter()
+        .copied()
+        .map(u16::from_le_bytes)
 }
 
 /// Parse a Match_Desc_req payload (2.4.3.1.7).

--- a/zigbee/src/zdo/descriptor.rs
+++ b/zigbee/src/zdo/descriptor.rs
@@ -1,9 +1,9 @@
 //! Device descriptor configuration and ZDP discovery responses.
 //!
-//! Holds the node/endpoint descriptors this device advertises and builds the
-//! matching ZDP `*_rsp` payloads (2.4.4) used to answer the discovery requests
-//! a coordinator issues during interview (Node_Desc, Active_EP, Simple_Desc,
-//! IEEE_addr, NWK_addr).
+//! Holds the node/power/endpoint descriptors this device advertises and builds
+//! the matching ZDP `*_rsp` payloads (2.4.4) used to answer the discovery
+//! requests a coordinator issues during interview (Node_Desc, Power_Desc,
+//! Active_EP, Simple_Desc, Match_Desc, IEEE_addr, NWK_addr).
 
 use byte::BytesExt;
 use byte::ctx;
@@ -16,8 +16,10 @@ use crate::nwk::nlme::management::NlmeLeaveStatus;
 pub const NWK_ADDR_REQ: u16 = 0x0000;
 pub const IEEE_ADDR_REQ: u16 = 0x0001;
 pub const NODE_DESC_REQ: u16 = 0x0002;
+pub const POWER_DESC_REQ: u16 = 0x0003;
 pub const SIMPLE_DESC_REQ: u16 = 0x0004;
 pub const ACTIVE_EP_REQ: u16 = 0x0005;
+pub const MATCH_DESC_REQ: u16 = 0x0006;
 pub const BIND_REQ: u16 = 0x0021;
 pub const UNBIND_REQ: u16 = 0x0022;
 pub const MGMT_LEAVE_REQ: u16 = 0x0034;
@@ -26,8 +28,10 @@ pub const MGMT_LEAVE_REQ: u16 = 0x0034;
 pub const NWK_ADDR_RSP: u16 = 0x8000;
 pub const IEEE_ADDR_RSP: u16 = 0x8001;
 pub const NODE_DESC_RSP: u16 = 0x8002;
+pub const POWER_DESC_RSP: u16 = 0x8003;
 pub const SIMPLE_DESC_RSP: u16 = 0x8004;
 pub const ACTIVE_EP_RSP: u16 = 0x8005;
+pub const MATCH_DESC_RSP: u16 = 0x8006;
 pub const BIND_RSP: u16 = 0x8021;
 pub const UNBIND_RSP: u16 = 0x8022;
 pub const MGMT_LEAVE_RSP: u16 = 0x8034;
@@ -49,6 +53,10 @@ const MGMT_LEAVE_REMOVE_CHILDREN: u8 = 0b0100_0000;
 const MGMT_LEAVE_REJOIN: u8 = 0b1000_0000;
 
 const NODE_DESCRIPTOR_SIZE: usize = 13;
+const POWER_DESCRIPTOR_SIZE: usize = 2;
+
+// a Match_Desc_req profile of 0xffff matches every endpoint (2.4.4.2.7.1.1)
+const WILDCARD_PROFILE_ID: u16 = 0xffff;
 
 /// Static configuration of the node descriptor (2.3.2.3).
 #[derive(Debug, Clone, Copy)]
@@ -91,6 +99,42 @@ impl NodeDescriptorConfig {
         out.write_with(offset, self.server_mask, ctx::LE)?;
         out.write_with(offset, self.maximum_outgoing_transfer_size, ctx::LE)?;
         out.write_with(offset, self.descriptor_capability_field, ctx::LE)?;
+        Ok(*offset)
+    }
+}
+
+/// Static configuration of the node power descriptor (2.3.2.4).
+#[derive(Debug, Clone, Copy)]
+pub struct PowerDescriptorConfig {
+    /// Sleep/power-saving mode (2.3.2.4.1): `0x0` receiver on when idle,
+    /// `0x1` periodically on, `0x2` on when stimulated.
+    pub current_power_mode: u8,
+    /// Bitmap of the sources present (2.3.2.4.2): bit 0 constant/mains,
+    /// bit 1 rechargeable battery, bit 2 disposable battery.
+    pub available_power_sources: u8,
+    /// Bitmap (same bit assignment) with the source currently in use set
+    /// (2.3.2.4.3).
+    pub current_power_source: u8,
+    /// Charge level (2.3.2.4.4): `0b0000` critical, `0b0100` 33%,
+    /// `0b1000` 66%, `0b1100` 100%.
+    pub current_power_source_level: u8,
+}
+
+impl PowerDescriptorConfig {
+    // serialize the 2-byte node power descriptor (2.3.2.4); each octet holds
+    // the earlier-transmitted field in its low nibble
+    fn write(&self, out: &mut [u8]) -> Result<usize, byte::Error> {
+        let offset = &mut 0;
+        out.write_with(
+            offset,
+            (self.current_power_mode & 0x0f) | ((self.available_power_sources & 0x0f) << 4),
+            ctx::LE,
+        )?;
+        out.write_with(
+            offset,
+            (self.current_power_source & 0x0f) | ((self.current_power_source_level & 0x0f) << 4),
+            ctx::LE,
+        )?;
         Ok(*offset)
     }
 }
@@ -138,6 +182,7 @@ impl EndpointDescriptor<'_> {
 #[derive(Debug, Clone, Copy)]
 pub struct DeviceDescriptorConfig<'a> {
     pub node: NodeDescriptorConfig,
+    pub power: PowerDescriptorConfig,
     pub endpoints: &'a [EndpointDescriptor<'a>],
 }
 
@@ -168,6 +213,51 @@ impl DeviceDescriptorConfig<'_> {
         out[*offset..*offset + n].copy_from_slice(&nd[..n]);
         *offset += n;
         Ok(*offset)
+    }
+
+    /// Build a Power_Desc_rsp payload (2.4.4.2.4): seq, status,
+    /// NWKAddrOfInterest, power descriptor.
+    pub fn power_desc_rsp(
+        &self,
+        seq: u8,
+        nwk_addr: u16,
+        out: &mut [u8],
+    ) -> Result<usize, byte::Error> {
+        let offset = &mut 0;
+        out.write_with(offset, seq, ctx::LE)?;
+        out.write_with(offset, STATUS_SUCCESS, ctx::LE)?;
+        out.write_with(offset, nwk_addr, ctx::LE)?;
+        let mut pd = [0u8; POWER_DESCRIPTOR_SIZE];
+        let n = self.power.write(&mut pd)?;
+        out[*offset..*offset + n].copy_from_slice(&pd[..n]);
+        *offset += n;
+        Ok(*offset)
+    }
+
+    /// Endpoints matching the request (2.4.4.2.7.1.1), written into `out`.
+    ///
+    /// Returns how many were written.
+    pub fn matching_endpoints(&self, request: &MatchDescReq<'_>, out: &mut [u8]) -> usize {
+        let mut count = 0;
+        for ep in self.endpoints {
+            if request.profile_id != WILDCARD_PROFILE_ID && request.profile_id != ep.profile_id {
+                continue;
+            }
+            let matches = request
+                .input_clusters()
+                .any(|cluster| ep.input_clusters.contains(&cluster))
+                || request
+                    .output_clusters()
+                    .any(|cluster| ep.output_clusters.contains(&cluster));
+            if matches {
+                let Some(slot) = out.get_mut(count) else {
+                    break;
+                };
+                *slot = ep.endpoint;
+                count += 1;
+            }
+        }
+        count
     }
 
     /// Build an Active_EP_rsp payload (2.4.4.2.6): seq, status,
@@ -323,6 +413,99 @@ pub fn bind_rsp(seq: u8, status: BindStatus, out: &mut [u8]) -> Result<usize, by
     Ok(*offset)
 }
 
+/// A parsed Match_Desc_req (2.4.3.1.7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MatchDescReq<'a> {
+    /// ZDP transaction sequence number to echo in the response.
+    pub seq: u8,
+    pub nwk_addr_of_interest: u16,
+    pub profile_id: u16,
+    input_clusters: &'a [u8],
+    output_clusters: &'a [u8],
+}
+
+impl MatchDescReq<'_> {
+    /// Input cluster identifiers to match against.
+    pub fn input_clusters(&self) -> impl Iterator<Item = u16> + '_ {
+        cluster_ids(self.input_clusters)
+    }
+
+    /// Output cluster identifiers to match against.
+    pub fn output_clusters(&self) -> impl Iterator<Item = u16> + '_ {
+        cluster_ids(self.output_clusters)
+    }
+}
+
+fn cluster_ids(bytes: &[u8]) -> impl Iterator<Item = u16> + '_ {
+    bytes
+        .chunks_exact(2)
+        .map(|pair| u16::from_le_bytes([pair[0], pair[1]]))
+}
+
+/// Parse a Match_Desc_req payload (2.4.3.1.7).
+///
+/// Returns `None` if the payload is truncated or a declared cluster count runs
+/// past the end of the ASDU.
+pub fn parse_match_desc_req(asdu: &[u8]) -> Option<MatchDescReq<'_>> {
+    let seq = *asdu.first()?;
+    let nwk_addr_of_interest = u16::from_le_bytes(asdu.get(1..3)?.try_into().ok()?);
+    let profile_id = u16::from_le_bytes(asdu.get(3..5)?.try_into().ok()?);
+
+    let in_count = usize::from(*asdu.get(5)?);
+    let in_end = 6 + in_count * 2;
+    let input_clusters = asdu.get(6..in_end)?;
+
+    let out_count = usize::from(*asdu.get(in_end)?);
+    let out_start = in_end + 1;
+    let output_clusters = asdu.get(out_start..out_start + out_count * 2)?;
+
+    Some(MatchDescReq {
+        seq,
+        nwk_addr_of_interest,
+        profile_id,
+        input_clusters,
+        output_clusters,
+    })
+}
+
+/// Build a Match_Desc_rsp payload (2.4.4.2.7): seq, status,
+/// NWKAddrOfInterest, MatchLength, MatchList.
+pub fn match_desc_rsp(
+    seq: u8,
+    nwk_addr: u16,
+    matches: &[u8],
+    out: &mut [u8],
+) -> Result<usize, byte::Error> {
+    let offset = &mut 0;
+    out.write_with(offset, seq, ctx::LE)?;
+    out.write_with(offset, STATUS_SUCCESS, ctx::LE)?;
+    out.write_with(offset, nwk_addr, ctx::LE)?;
+    out.write_with(
+        offset,
+        u8::try_from(matches.len()).unwrap_or(u8::MAX),
+        ctx::LE,
+    )?;
+    for &endpoint in matches {
+        out.write_with(offset, endpoint, ctx::LE)?;
+    }
+    Ok(*offset)
+}
+
+/// Build a Match_Desc_rsp carrying only Status and MatchLength (2.4.4.2.7
+/// step 2.b.iii), for a unicast request about another device.
+///
+/// NWKAddrOfInterest is omitted on purpose: the error paths of 2.4.4.2.7
+/// (steps 2.b.iii, 4.b.ii, 6.b) all specify Status and MatchLength only, and
+/// only the success path (step 7.b) carries the address. Dissectors that model
+/// the response as a fixed layout report the short frame as malformed.
+pub fn match_desc_rsp_invalid_request(seq: u8, out: &mut [u8]) -> Result<usize, byte::Error> {
+    let offset = &mut 0;
+    out.write_with(offset, seq, ctx::LE)?;
+    out.write_with(offset, STATUS_INV_REQUESTTYPE, ctx::LE)?;
+    out.write_with(offset, 0u8, ctx::LE)?;
+    Ok(*offset)
+}
+
 /// A parsed Mgmt_Leave_req (2.4.3.3.5).
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct MgmtLeaveReq {
@@ -394,18 +577,27 @@ mod tests {
         descriptor_capability_field: 0,
     };
 
+    // mains-powered, on when idle, 100% charge
+    const POWER: PowerDescriptorConfig = PowerDescriptorConfig {
+        current_power_mode: 0b0000,
+        available_power_sources: 0b0001,
+        current_power_source: 0b0001,
+        current_power_source_level: 0b1100,
+    };
+
     const ENDPOINTS: [EndpointDescriptor; 1] = [EndpointDescriptor {
         endpoint: 1,
         profile_id: 0x0104,
         device_id: 0x0302,
         device_version: 1,
         input_clusters: &[0x0000, 0x0402],
-        output_clusters: &[],
+        output_clusters: &[0x0019],
     }];
 
     fn cfg() -> DeviceDescriptorConfig<'static> {
         DeviceDescriptorConfig {
             node: NODE,
+            power: POWER,
             endpoints: &ENDPOINTS,
         }
     }
@@ -444,13 +636,13 @@ mod tests {
             &out[..n],
             &[
                 0x07, 0x00, 0x34, 0x12, // seq, status, NWKAddrOfInterest
-                0x0c, // length
+                0x0e, // length
                 0x01, // endpoint
                 0x04, 0x01, // profile id
                 0x02, 0x03, // device id
                 0x01, // device version
                 0x02, 0x00, 0x00, 0x02, 0x04, // input count + clusters
-                0x00, // output count
+                0x01, 0x19, 0x00, // output count + clusters
             ]
         );
     }
@@ -461,6 +653,106 @@ mod tests {
         let n = cfg().simple_desc_rsp(0x07, 0x1234, 9, &mut out).unwrap();
         // status NOT_ACTIVE (0x83), length 0, no descriptor
         assert_eq!(&out[..n], &[0x07, 0x83, 0x34, 0x12, 0x00]);
+    }
+
+    #[test]
+    fn power_desc_rsp_layout() {
+        let mut out = [0u8; 16];
+        let n = cfg().power_desc_rsp(0x07, 0x1234, &mut out).unwrap();
+        assert_eq!(
+            &out[..n],
+            &[
+                0x07, 0x00, 0x34, 0x12, // seq, status, NWKAddrOfInterest
+                0x10, // current power mode | available sources << 4
+                0xc1, // current source | level << 4
+            ]
+        );
+    }
+
+    // 2.4.3.1.7: seq, NWKAddrOfInterest, ProfileID, then both cluster lists
+    const MATCH_REQ: [u8; 13] = [
+        0x33, // seq
+        0x34, 0x12, // NWKAddrOfInterest
+        0x04, 0x01, // profile id 0x0104
+        0x02, 0x00, 0x00, 0x02, 0x04, // 2 input clusters: 0x0000, 0x0402
+        0x01, 0x19, 0x00, // 1 output cluster: 0x0019
+    ];
+
+    #[test]
+    fn parse_match_desc_req_lists() {
+        let req = parse_match_desc_req(&MATCH_REQ).unwrap();
+        assert_eq!(req.seq, 0x33);
+        assert_eq!(req.nwk_addr_of_interest, 0x1234);
+        assert_eq!(req.profile_id, 0x0104);
+        assert!(req.input_clusters().eq([0x0000, 0x0402]));
+        assert!(req.output_clusters().eq([0x0019]));
+    }
+
+    #[test]
+    fn parse_match_desc_req_rejects_truncated_list() {
+        // declares two input clusters but carries one and a half
+        assert!(parse_match_desc_req(&MATCH_REQ[..8]).is_none());
+        // missing the output cluster count entirely
+        assert!(parse_match_desc_req(&MATCH_REQ[..10]).is_none());
+        assert!(parse_match_desc_req(&[0x33, 0x34]).is_none());
+    }
+
+    #[test]
+    fn matching_endpoints_by_input_cluster() {
+        // temperature measurement is an input cluster on endpoint 1
+        let asdu = [0x33, 0x34, 0x12, 0x04, 0x01, 0x01, 0x02, 0x04, 0x00];
+        let req = parse_match_desc_req(&asdu).unwrap();
+        let mut out = [0u8; 4];
+        assert_eq!(cfg().matching_endpoints(&req, &mut out), 1);
+        assert_eq!(out[0], 1);
+    }
+
+    #[test]
+    fn matching_endpoints_by_output_cluster() {
+        // OTA (0x0019) is an output cluster on endpoint 1
+        let asdu = [0x33, 0x34, 0x12, 0x04, 0x01, 0x00, 0x01, 0x19, 0x00];
+        let req = parse_match_desc_req(&asdu).unwrap();
+        let mut out = [0u8; 4];
+        assert_eq!(cfg().matching_endpoints(&req, &mut out), 1);
+    }
+
+    #[test]
+    fn matching_endpoints_wildcard_profile() {
+        // profile 0xffff matches regardless of the endpoint's profile
+        let asdu = [0x33, 0x34, 0x12, 0xff, 0xff, 0x01, 0x02, 0x04, 0x00];
+        let req = parse_match_desc_req(&asdu).unwrap();
+        let mut out = [0u8; 4];
+        assert_eq!(cfg().matching_endpoints(&req, &mut out), 1);
+    }
+
+    #[test]
+    fn matching_endpoints_rejects_wrong_profile_and_unknown_cluster() {
+        // right cluster, wrong profile
+        let asdu = [0x33, 0x34, 0x12, 0x09, 0x01, 0x01, 0x02, 0x04, 0x00];
+        let req = parse_match_desc_req(&asdu).unwrap();
+        let mut out = [0u8; 4];
+        assert_eq!(cfg().matching_endpoints(&req, &mut out), 0);
+
+        // right profile, cluster we do not serve
+        let asdu = [0x33, 0x34, 0x12, 0x04, 0x01, 0x01, 0x06, 0x00, 0x00];
+        let req = parse_match_desc_req(&asdu).unwrap();
+        assert_eq!(cfg().matching_endpoints(&req, &mut out), 0);
+    }
+
+    #[test]
+    fn match_desc_rsp_layout() {
+        let mut out = [0u8; 16];
+        let n = match_desc_rsp(0x33, 0x1234, &[1], &mut out).unwrap();
+        assert_eq!(&out[..n], &[0x33, 0x00, 0x34, 0x12, 0x01, 0x01]);
+    }
+
+    #[test]
+    fn match_desc_rsp_invalid_request_omits_address() {
+        let mut out = [0u8; 16];
+        let n = match_desc_rsp_invalid_request(0x33, &mut out).unwrap();
+        // seq, INV_REQUESTTYPE, MatchLength — no NWKAddrOfInterest (2.4.4.2.7
+        // step 2.b.iii)
+        assert_eq!(&out[..n], &[0x33, 0x80, 0x00]);
     }
 
     #[test]

--- a/zigbee/src/zdo/descriptor.rs
+++ b/zigbee/src/zdo/descriptor.rs
@@ -10,6 +10,9 @@ use byte::ctx;
 use zigbee_types::IeeeAddress;
 
 use crate::apl::descriptors::node_descriptor::LogicalType;
+use crate::apl::descriptors::node_power_descriptor::CurrentPowerMode;
+use crate::apl::descriptors::node_power_descriptor::CurrentPowerSourceLevel;
+use crate::apl::descriptors::node_power_descriptor::PowerSource;
 use crate::nwk::nlme::management::NlmeLeaveStatus;
 
 // ZDP request cluster identifiers (2.4.3).
@@ -58,6 +61,18 @@ const POWER_DESCRIPTOR_SIZE: usize = 2;
 // a Match_Desc_req profile of 0xffff matches every endpoint (2.4.4.2.7.1.1)
 const WILDCARD_PROFILE_ID: u16 = 0xffff;
 
+// append raw bytes at offset, reporting a short buffer instead of panicking
+fn append(out: &mut [u8], offset: &mut usize, bytes: &[u8]) -> Result<(), byte::Error> {
+    let end = offset
+        .checked_add(bytes.len())
+        .ok_or(byte::Error::Incomplete)?;
+    out.get_mut(*offset..end)
+        .ok_or(byte::Error::Incomplete)?
+        .copy_from_slice(bytes);
+    *offset = end;
+    Ok(())
+}
+
 /// Static configuration of the node descriptor (2.3.2.3).
 #[derive(Debug, Clone, Copy)]
 pub struct NodeDescriptorConfig {
@@ -105,34 +120,31 @@ impl NodeDescriptorConfig {
 
 /// Static configuration of the node power descriptor (2.3.2.4).
 #[derive(Debug, Clone, Copy)]
-pub struct PowerDescriptorConfig {
-    /// Sleep/power-saving mode (2.3.2.4.1): `0x0` receiver on when idle,
-    /// `0x1` periodically on, `0x2` on when stimulated.
-    pub current_power_mode: u8,
-    /// Bitmap of the sources present (2.3.2.4.2): bit 0 constant/mains,
-    /// bit 1 rechargeable battery, bit 2 disposable battery.
-    pub available_power_sources: u8,
-    /// Bitmap (same bit assignment) with the source currently in use set
-    /// (2.3.2.4.3).
-    pub current_power_source: u8,
-    /// Charge level (2.3.2.4.4): `0b0000` critical, `0b0100` 33%,
-    /// `0b1000` 66%, `0b1100` 100%.
-    pub current_power_source_level: u8,
+pub struct PowerDescriptorConfig<'a> {
+    /// Sleep/power-saving mode (2.3.2.4.1).
+    pub current_power_mode: CurrentPowerMode,
+    /// The power sources present on the node (2.3.2.4.2).
+    pub available_power_sources: &'a [PowerSource],
+    /// The source currently in use (2.3.2.4.3).
+    pub current_power_source: PowerSource,
+    /// Charge level of that source (2.3.2.4.4).
+    pub current_power_source_level: CurrentPowerSourceLevel,
 }
 
-impl PowerDescriptorConfig {
+impl PowerDescriptorConfig<'_> {
     // serialize the 2-byte node power descriptor (2.3.2.4); each octet holds
     // the earlier-transmitted field in its low nibble
     fn write(&self, out: &mut [u8]) -> Result<usize, byte::Error> {
         let offset = &mut 0;
         out.write_with(
             offset,
-            (self.current_power_mode & 0x0f) | ((self.available_power_sources & 0x0f) << 4),
+            self.current_power_mode.bits()
+                | (PowerSource::bitmap(self.available_power_sources) << 4),
             ctx::LE,
         )?;
         out.write_with(
             offset,
-            (self.current_power_source & 0x0f) | ((self.current_power_source_level & 0x0f) << 4),
+            self.current_power_source.bits() | (self.current_power_source_level.bits() << 4),
             ctx::LE,
         )?;
         Ok(*offset)
@@ -182,7 +194,7 @@ impl EndpointDescriptor<'_> {
 #[derive(Debug, Clone, Copy)]
 pub struct DeviceDescriptorConfig<'a> {
     pub node: NodeDescriptorConfig,
-    pub power: PowerDescriptorConfig,
+    pub power: PowerDescriptorConfig<'a>,
     pub endpoints: &'a [EndpointDescriptor<'a>],
 }
 
@@ -210,8 +222,7 @@ impl DeviceDescriptorConfig<'_> {
         out.write_with(offset, nwk_addr, ctx::LE)?;
         let mut nd = [0u8; NODE_DESCRIPTOR_SIZE];
         let n = self.node.write(&mut nd)?;
-        out[*offset..*offset + n].copy_from_slice(&nd[..n]);
-        *offset += n;
+        append(out, offset, &nd[..n])?;
         Ok(*offset)
     }
 
@@ -229,8 +240,7 @@ impl DeviceDescriptorConfig<'_> {
         out.write_with(offset, nwk_addr, ctx::LE)?;
         let mut pd = [0u8; POWER_DESCRIPTOR_SIZE];
         let n = self.power.write(&mut pd)?;
-        out[*offset..*offset + n].copy_from_slice(&pd[..n]);
-        *offset += n;
+        append(out, offset, &pd[..n])?;
         Ok(*offset)
     }
 
@@ -302,8 +312,7 @@ impl DeviceDescriptorConfig<'_> {
             out.write_with(offset, STATUS_SUCCESS, ctx::LE)?;
             out.write_with(offset, nwk_addr, ctx::LE)?;
             out.write_with(offset, u8::try_from(len).unwrap_or(u8::MAX), ctx::LE)?;
-            out[*offset..*offset + len].copy_from_slice(&desc[..len]);
-            *offset += len;
+            append(out, offset, &desc[..len])?;
         } else {
             out.write_with(offset, STATUS_NOT_ACTIVE, ctx::LE)?;
             out.write_with(offset, nwk_addr, ctx::LE)?;
@@ -494,17 +503,34 @@ pub fn match_desc_rsp(
     Ok(*offset)
 }
 
-/// Build a Match_Desc_rsp carrying only Status and MatchLength (2.4.4.2.7
-/// step 2.b.iii), for a unicast request about another device.
+/// Why a Match_Desc_req could not be answered with a match list (2.4.4.2.7).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MatchDescError {
+    /// The request named another device and this device cannot answer for it
+    /// (step 2.b.i).
+    InvalidRequestType,
+    /// The request named a device this router knows nothing about (step 4.b.i).
+    DeviceNotFound,
+}
+
+/// Build a Match_Desc_rsp carrying only Status and MatchLength (2.4.4.2.7).
 ///
 /// NWKAddrOfInterest is omitted on purpose: the error paths of 2.4.4.2.7
 /// (steps 2.b.iii, 4.b.ii, 6.b) all specify Status and MatchLength only, and
 /// only the success path (step 7.b) carries the address. Dissectors that model
 /// the response as a fixed layout report the short frame as malformed.
-pub fn match_desc_rsp_invalid_request(seq: u8, out: &mut [u8]) -> Result<usize, byte::Error> {
+pub fn match_desc_rsp_error(
+    seq: u8,
+    error: MatchDescError,
+    out: &mut [u8],
+) -> Result<usize, byte::Error> {
+    let status = match error {
+        MatchDescError::InvalidRequestType => STATUS_INV_REQUESTTYPE,
+        MatchDescError::DeviceNotFound => STATUS_DEVICE_NOT_FOUND,
+    };
     let offset = &mut 0;
     out.write_with(offset, seq, ctx::LE)?;
-    out.write_with(offset, STATUS_INV_REQUESTTYPE, ctx::LE)?;
+    out.write_with(offset, status, ctx::LE)?;
     out.write_with(offset, 0u8, ctx::LE)?;
     Ok(*offset)
 }
@@ -582,10 +608,10 @@ mod tests {
 
     // mains-powered, on when idle, 100% charge
     const POWER: PowerDescriptorConfig = PowerDescriptorConfig {
-        current_power_mode: 0b0000,
-        available_power_sources: 0b0001,
-        current_power_source: 0b0001,
-        current_power_source_level: 0b1100,
+        current_power_mode: CurrentPowerMode::Synchronized,
+        available_power_sources: &[PowerSource::ConstantMainPower],
+        current_power_source: PowerSource::ConstantMainPower,
+        current_power_source_level: CurrentPowerSourceLevel::Full,
     };
 
     const ENDPOINTS: [EndpointDescriptor; 1] = [EndpointDescriptor {
@@ -750,12 +776,24 @@ mod tests {
     }
 
     #[test]
-    fn match_desc_rsp_invalid_request_omits_address() {
+    fn match_desc_rsp_error_omits_address() {
         let mut out = [0u8; 16];
-        let n = match_desc_rsp_invalid_request(0x33, &mut out).unwrap();
+        let n = match_desc_rsp_error(0x33, MatchDescError::InvalidRequestType, &mut out).unwrap();
         // seq, INV_REQUESTTYPE, MatchLength — no NWKAddrOfInterest (2.4.4.2.7
         // step 2.b.iii)
         assert_eq!(&out[..n], &[0x33, 0x80, 0x00]);
+
+        let n = match_desc_rsp_error(0x33, MatchDescError::DeviceNotFound, &mut out).unwrap();
+        assert_eq!(&out[..n], &[0x33, 0x81, 0x00]);
+    }
+
+    #[test]
+    fn descriptor_rsp_reports_short_buffer_instead_of_panicking() {
+        // room for seq, status and NWKAddrOfInterest, but not the descriptor
+        let mut out = [0u8; 4];
+        assert!(cfg().power_desc_rsp(0x07, 0x1234, &mut out).is_err());
+        assert!(cfg().node_desc_rsp(0x07, 0x1234, &mut out).is_err());
+        assert!(cfg().simple_desc_rsp(0x07, 0x1234, 1, &mut out).is_err());
     }
 
     #[test]

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -30,6 +30,7 @@ use crate::aps::frame::command::Command;
 use crate::aps::frame::command::TransportKey;
 use crate::aps::types::TxOptions;
 use crate::nwk::nib;
+use crate::nwk::nib::NWK_BROADCAST_ADDRESS_MIN;
 use crate::nwk::nib::NetworkSecurityMaterialDescriptor;
 use crate::nwk::nlme::NetworkError;
 use crate::nwk::nlme::Nlme;
@@ -66,6 +67,9 @@ pub struct ZigBeeNetwork {}
 const ZDP_PROFILE_ID: u16 = 0x0000;
 const ZDO_ENDPOINT: u8 = 0x00;
 
+// an endpoint appears at most once in a MatchList (2.4.4.2.7 step 3.b)
+const MAX_MATCHING_ENDPOINTS: usize = 16;
+
 /// Handler for inbound application-profile (non-ZDP) requests.
 ///
 /// Implemented by cluster servers (e.g. the ZCL Basic cluster) to answer
@@ -83,6 +87,29 @@ pub trait ClusterRequestHandler {
         asdu: &[u8],
         out: &mut [u8],
     ) -> Option<usize>;
+}
+
+/// Lets a handler be shared by reference, so a cluster server the application
+/// also reads from can live outside the receive task.
+impl<T: ClusterRequestHandler + ?Sized> ClusterRequestHandler for &T {
+    fn handle(
+        &self,
+        profile_id: u16,
+        cluster_id: u16,
+        src_endpoint: u8,
+        dst_endpoint: u8,
+        asdu: &[u8],
+        out: &mut [u8],
+    ) -> Option<usize> {
+        (**self).handle(
+            profile_id,
+            cluster_id,
+            src_endpoint,
+            dst_endpoint,
+            asdu,
+            out,
+        )
+    }
 }
 
 /// Chains two handlers: the first to produce a response wins. Lets an
@@ -110,6 +137,33 @@ impl<A: ClusterRequestHandler, B: ClusterRequestHandler> ClusterRequestHandler f
             return Some(len);
         }
         self.1.handle(
+            profile_id,
+            cluster_id,
+            src_endpoint,
+            dst_endpoint,
+            asdu,
+            out,
+        )
+    }
+}
+
+/// Chains three handlers, left to right.
+impl<A, B, C> ClusterRequestHandler for (A, B, C)
+where
+    A: ClusterRequestHandler,
+    B: ClusterRequestHandler,
+    C: ClusterRequestHandler,
+{
+    fn handle(
+        &self,
+        profile_id: u16,
+        cluster_id: u16,
+        src_endpoint: u8,
+        dst_endpoint: u8,
+        asdu: &[u8],
+        out: &mut [u8],
+    ) -> Option<usize> {
+        (&self.0, (&self.1, &self.2)).handle(
             profile_id,
             cluster_id,
             src_endpoint,
@@ -593,12 +647,15 @@ impl<M: Mlme> ZigbeeDevice<M> {
         let mut leave_after_reply = None;
 
         // (response cluster, profile, dst endpoint, src endpoint, length)
+        // a broadcast is answered differently from a unicast, both for
+        // Match_Desc_req (2.4.4.2.7) and Mgmt_Leave_req (3.6.1.10.3 step 1)
+        let nwk_dst = match indication.dst_address {
+            Address::Network(dst) => dst,
+            _ => *self.nlme.nib().network_address(),
+        };
+
         let response = if profile == ZDP_PROFILE_ID && cluster == descriptor::MGMT_LEAVE_REQ {
-            let destination = match indication.dst_address {
-                Address::Network(dst) => ShortAddress(dst),
-                _ => ShortAddress(*self.nlme.nib().network_address()),
-            };
-            self.build_mgmt_leave_rsp(indication.asdu, destination, &mut out)
+            self.build_mgmt_leave_rsp(indication.asdu, ShortAddress(nwk_dst), &mut out)
                 .map(|(len, request)| {
                     leave_after_reply = request;
                     (
@@ -610,7 +667,7 @@ impl<M: Mlme> ZigbeeDevice<M> {
                     )
                 })
         } else if profile == ZDP_PROFILE_ID {
-            self.build_zdp_response(cluster, indication.asdu, cfg, &mut out)
+            self.build_zdp_response(cluster, indication.asdu, nwk_dst, cfg, &mut out)
                 .map(|(rsp_cluster, len)| {
                     (rsp_cluster, ZDP_PROFILE_ID, ZDO_ENDPOINT, ZDO_ENDPOINT, len)
                 })
@@ -662,6 +719,44 @@ impl<M: Mlme> ZigbeeDevice<M> {
     // NLME-LEAVE.request to issue once the response has been sent. only a
     // request naming this device (or the NULL address) is honored — removing
     // a child requires acting as its parent, which this stack does not support
+    // answer a Match_Desc_req as an end device (2.4.4.2.7): a broadcast about
+    // another device (step 2.a) or without a match (step 5) stays silent, a
+    // unicast about another device gets INV_REQUESTTYPE (step 2.b)
+    fn build_match_desc_rsp(
+        &self,
+        asdu: &[u8],
+        nwk_dst: u16,
+        nwk_addr: u16,
+        cfg: &descriptor::DeviceDescriptorConfig<'_>,
+        out: &mut [u8],
+    ) -> Option<(u16, usize)> {
+        let request = descriptor::parse_match_desc_req(asdu)?;
+        let broadcast = nwk_dst >= NWK_BROADCAST_ADDRESS_MIN;
+        let about_us = request.nwk_addr_of_interest == nwk_addr
+            || request.nwk_addr_of_interest >= NWK_BROADCAST_ADDRESS_MIN;
+
+        if !about_us {
+            if broadcast {
+                return None;
+            }
+            return Some((
+                descriptor::MATCH_DESC_RSP,
+                descriptor::match_desc_rsp_invalid_request(request.seq, out).ok()?,
+            ));
+        }
+
+        let mut matches = [0u8; MAX_MATCHING_ENDPOINTS];
+        let count = cfg.matching_endpoints(&request, &mut matches);
+        if count == 0 && broadcast {
+            return None;
+        }
+
+        Some((
+            descriptor::MATCH_DESC_RSP,
+            descriptor::match_desc_rsp(request.seq, nwk_addr, &matches[..count], out).ok()?,
+        ))
+    }
+
     fn build_mgmt_leave_rsp(
         &self,
         asdu: &[u8],
@@ -772,6 +867,7 @@ impl<M: Mlme> ZigbeeDevice<M> {
         &self,
         cluster: u16,
         asdu: &[u8],
+        nwk_dst: u16,
         cfg: &descriptor::DeviceDescriptorConfig<'_>,
         out: &mut [u8],
     ) -> Option<(u16, usize)> {
@@ -784,6 +880,13 @@ impl<M: Mlme> ZigbeeDevice<M> {
                 descriptor::NODE_DESC_RSP,
                 cfg.node_desc_rsp(seq, nwk_addr, out).ok()?,
             ),
+            descriptor::POWER_DESC_REQ => (
+                descriptor::POWER_DESC_RSP,
+                cfg.power_desc_rsp(seq, nwk_addr, out).ok()?,
+            ),
+            descriptor::MATCH_DESC_REQ => {
+                return self.build_match_desc_rsp(asdu, nwk_dst, nwk_addr, cfg, out);
+            }
             descriptor::ACTIVE_EP_REQ => (
                 descriptor::ACTIVE_EP_RSP,
                 cfg.active_ep_rsp(seq, nwk_addr, out).ok()?,

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -70,6 +70,20 @@ const ZDO_ENDPOINT: u8 = 0x00;
 // an endpoint appears at most once in a MatchList (2.4.4.2.7 step 3.b)
 const MAX_MATCHING_ENDPOINTS: usize = 16;
 
+/// One inbound application-profile request handed to a
+/// [`ClusterRequestHandler`].
+#[derive(Debug, Clone, Copy)]
+pub struct ClusterRequest<'a> {
+    pub profile_id: u16,
+    pub cluster_id: u16,
+    pub src_endpoint: u8,
+    pub dst_endpoint: u8,
+    /// Whether the frame was addressed to this device alone; a broadcast must
+    /// not draw a ZCL Default Response (ZCL 2.5.12.2).
+    pub unicast: bool,
+    pub asdu: &'a [u8],
+}
+
 /// Handler for inbound application-profile (non-ZDP) requests.
 ///
 /// Implemented by cluster servers (e.g. the ZCL Basic cluster) to answer
@@ -78,37 +92,14 @@ const MAX_MATCHING_ENDPOINTS: usize = 16;
 pub trait ClusterRequestHandler {
     /// Build a response ASDU for an application-profile request, writing it
     /// into `out` and returning its length, or `None` for no reply.
-    fn handle(
-        &self,
-        profile_id: u16,
-        cluster_id: u16,
-        src_endpoint: u8,
-        dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize>;
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize>;
 }
 
 /// Lets a handler be shared by reference, so a cluster server the application
 /// also reads from can live outside the receive task.
 impl<T: ClusterRequestHandler + ?Sized> ClusterRequestHandler for &T {
-    fn handle(
-        &self,
-        profile_id: u16,
-        cluster_id: u16,
-        src_endpoint: u8,
-        dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        (**self).handle(
-            profile_id,
-            cluster_id,
-            src_endpoint,
-            dst_endpoint,
-            asdu,
-            out,
-        )
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        (**self).handle(request, out)
     }
 }
 
@@ -117,33 +108,10 @@ impl<T: ClusterRequestHandler + ?Sized> ClusterRequestHandler for &T {
 /// plus a generic reporting responder) into the single handler
 /// [`ZigbeeDevice::rx_loop`] expects.
 impl<A: ClusterRequestHandler, B: ClusterRequestHandler> ClusterRequestHandler for (A, B) {
-    fn handle(
-        &self,
-        profile_id: u16,
-        cluster_id: u16,
-        src_endpoint: u8,
-        dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        if let Some(len) = self.0.handle(
-            profile_id,
-            cluster_id,
-            src_endpoint,
-            dst_endpoint,
-            asdu,
-            out,
-        ) {
-            return Some(len);
-        }
-        self.1.handle(
-            profile_id,
-            cluster_id,
-            src_endpoint,
-            dst_endpoint,
-            asdu,
-            out,
-        )
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        self.0
+            .handle(request, out)
+            .or_else(|| self.1.handle(request, out))
     }
 }
 
@@ -154,23 +122,8 @@ where
     B: ClusterRequestHandler,
     C: ClusterRequestHandler,
 {
-    fn handle(
-        &self,
-        profile_id: u16,
-        cluster_id: u16,
-        src_endpoint: u8,
-        dst_endpoint: u8,
-        asdu: &[u8],
-        out: &mut [u8],
-    ) -> Option<usize> {
-        (&self.0, (&self.1, &self.2)).handle(
-            profile_id,
-            cluster_id,
-            src_endpoint,
-            dst_endpoint,
-            asdu,
-            out,
-        )
+    fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
+        (&self.0, (&self.1, &self.2)).handle(request, out)
     }
 }
 
@@ -672,15 +625,16 @@ impl<M: Mlme> ZigbeeDevice<M> {
                     (rsp_cluster, ZDP_PROFILE_ID, ZDO_ENDPOINT, ZDO_ENDPOINT, len)
                 })
         } else {
+            let request = ClusterRequest {
+                profile_id: profile,
+                cluster_id: cluster,
+                src_endpoint,
+                dst_endpoint,
+                unicast: nwk_dst < NWK_BROADCAST_ADDRESS_MIN,
+                asdu: indication.asdu,
+            };
             handler
-                .handle(
-                    profile,
-                    cluster,
-                    src_endpoint,
-                    dst_endpoint,
-                    indication.asdu,
-                    &mut out,
-                )
+                .handle(&request, &mut out)
                 // application reply: same cluster/profile, endpoints swapped
                 .map(|len| (cluster, profile, src_endpoint, dst_endpoint, len))
         };
@@ -715,13 +669,11 @@ impl<M: Mlme> ZigbeeDevice<M> {
         Ok(())
     }
 
-    // build a Mgmt_Leave_rsp payload (2.4.4.4.5); returns its length and the
-    // NLME-LEAVE.request to issue once the response has been sent. only a
-    // request naming this device (or the NULL address) is honored — removing
-    // a child requires acting as its parent, which this stack does not support
-    // answer a Match_Desc_req as an end device (2.4.4.2.7): a broadcast about
-    // another device (step 2.a) or without a match (step 5) stays silent, a
-    // unicast about another device gets INV_REQUESTTYPE (step 2.b)
+    // answer a Match_Desc_req (2.4.4.2.7) about this device: a broadcast about
+    // another device (step 2.a) or without a match (step 5) stays silent. a
+    // request about another device is answered with INV_REQUESTTYPE by an end
+    // device (step 2.b) and with DEVICE_NOT_FOUND by a router, which keeps no
+    // cached simple descriptors for its children (step 4.b)
     fn build_match_desc_rsp(
         &self,
         asdu: &[u8],
@@ -736,12 +688,18 @@ impl<M: Mlme> ZigbeeDevice<M> {
             || request.nwk_addr_of_interest >= NWK_BROADCAST_ADDRESS_MIN;
 
         if !about_us {
-            if broadcast {
+            let end_device = cfg.node.logical_type == LogicalType::EndDevice;
+            if broadcast && end_device {
                 return None;
             }
+            let error = if end_device {
+                descriptor::MatchDescError::InvalidRequestType
+            } else {
+                descriptor::MatchDescError::DeviceNotFound
+            };
             return Some((
                 descriptor::MATCH_DESC_RSP,
-                descriptor::match_desc_rsp_invalid_request(request.seq, out).ok()?,
+                descriptor::match_desc_rsp_error(request.seq, error, out).ok()?,
             ));
         }
 
@@ -757,6 +715,10 @@ impl<M: Mlme> ZigbeeDevice<M> {
         ))
     }
 
+    // build a Mgmt_Leave_rsp payload (2.4.4.4.5); returns its length and the
+    // NLME-LEAVE.request to issue once the response has been sent. only a
+    // request naming this device (or the NULL address) is honored — removing
+    // a child requires acting as its parent, which this stack does not support
     fn build_mgmt_leave_rsp(
         &self,
         asdu: &[u8],


### PR DESCRIPTION
This PR add the answer `Power_Desc_req` and `Match_Desc_req`. A broadcast that matches nothing
gets no reply.

🚨 Quick side-quest: Fix: the APS indication reported our own address as the destination, hiding
whether a frame came in as a broadcast. It now reports the real one.