### PR TITLE
refactor: keepalive and usability improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ license = "MIT OR Apache-2.0"
 [workspace]
 members = [
     "zigbee",
+    "zigbee-app",
     "zigbee-base-device-behavior",
     "zigbee-cluster-library",
     "zigbee-macros",

--- a/examples/esp-sensor/Cargo.toml
+++ b/examples/esp-sensor/Cargo.toml
@@ -38,7 +38,7 @@ esp-storage = { version = "0.9.0", features = ["esp32c6"] }
 zigbee = { path = "../../zigbee", features = ["storage"] }
 zigbee-types = { version = "0.1.0", path = "../../zigbee-types" }
 zigbee-mac = { path = "../../zigbee-mac", features = ["esp32c6"] }
-zigbee-base-device-behavior = { path = "../../zigbee-base-device-behavior" }
+zigbee-app = { path = "../../zigbee-app", features = ["storage"] }
 zigbee-cluster-library = { path = "../../zigbee-cluster-library" }
 
 [profile.release]

--- a/examples/esp-sensor/src/main.rs
+++ b/examples/esp-sensor/src/main.rs
@@ -21,15 +21,15 @@ use zigbee::PowerSource;
 use zigbee::aps::aib;
 use zigbee::aps::apsde::ApsdeSapConfirmStatus;
 use zigbee::nwk::nib::CapabilityInformation;
-use zigbee::nwk::nlme::Nlme;
-use zigbee::nwk::nlme::management::NlmeJoinStatus;
-use zigbee::storage::StorageDriver;
-use zigbee::zdo::ZigbeeDevice;
+use zigbee::zdo::config::DiscoveryType;
 use zigbee::zdo::descriptor::DeviceDescriptorConfig;
 use zigbee::zdo::descriptor::EndpointDescriptor;
 use zigbee::zdo::descriptor::NodeDescriptorConfig;
 use zigbee::zdo::descriptor::PowerDescriptorConfig;
-use zigbee_base_device_behavior::BaseDeviceBehavior;
+use zigbee_app::DeviceConfig;
+use zigbee_app::NetworkConfig;
+use zigbee_app::TimingConfig;
+use zigbee_app::config::StackConfig;
 use zigbee_cluster_library::basic;
 use zigbee_cluster_library::basic::BasicServer;
 use zigbee_cluster_library::common::data_types::SignedN;
@@ -111,33 +111,61 @@ static BASIC: BasicServer = BasicServer {
 
 type ZigbeeFlash = zigbee::storage::FlashStorage<BlockingAsync<FlashStorage<'static>>>;
 
-static DEVICE: StaticCell<ZigbeeDevice<EspMlme<'static>>> = StaticCell::new();
-static STORAGE: StaticCell<ZigbeeFlash> = StaticCell::new();
+/// Cluster servers answering inbound requests, in the order they are tried.
+type Handler = (
+    BasicServer<'static>,
+    ConfigureReportingServer,
+    &'static IdentifyServer,
+);
 
-fn descriptor_config() -> DeviceDescriptorConfig<'static> {
-    DeviceDescriptorConfig {
-        node: NodeDescriptorConfig {
+/// The running stack this application's tasks share.
+type Stack = zigbee_app::Stack<'static, EspMlme<'static>, Handler, ZigbeeFlash>;
+
+static STACK: StaticCell<Stack> = StaticCell::new();
+
+/// Everything this application configures: the network to be on, what this
+/// device is, the cadences, and the descriptors served to an interviewer. The
+/// logical type and capability flags of the node descriptor are derived from
+/// the device configuration, so they cannot drift apart.
+fn stack_config() -> StackConfig<'static> {
+    StackConfig::new(
+        NetworkConfig {
+            extended_pan_id: IeeeAddress(EXTENDED_PAN_ID),
+            channels: CHANNEL..CHANNEL + 1,
+            scan_duration: SCAN_DURATION,
+        },
+        DeviceConfig {
             logical_type: LogicalType::EndDevice,
-            complex_descriptor_available: false,
-            user_descriptor_available: false,
-            // bit 3: 2400 MHz band.
-            frequency_band: 0x08,
-            mac_capability_flags: CAPABILITY,
-            manufacturer_code: 0x1037,
-            maximum_buffer_size: 80,
-            maximum_incoming_transfer_size: 128,
-            server_mask: 0,
-            maximum_outgoing_transfer_size: 128,
-            descriptor_capability_field: 0,
+            capability_information: CapabilityInformation(CAPABILITY),
+            discovery_type: DiscoveryType::default(),
+            tc_link_key_exchange: true,
         },
-        power: PowerDescriptorConfig {
-            current_power_mode: CurrentPowerMode::Stimulated,
-            available_power_sources: &[PowerSource::DisposableBattery],
-            current_power_source: PowerSource::DisposableBattery,
-            current_power_source_level: CurrentPowerSourceLevel::Full,
+        TimingConfig {
+            poll_interval_ms: POLL_INTERVAL_MS,
+            ..TimingConfig::default()
         },
-        endpoints: &ENDPOINTS,
-    }
+        DeviceDescriptorConfig {
+            node: NodeDescriptorConfig {
+                // logical_type and mac_capability_flags come from DeviceConfig
+                // bit 3: 2400 MHz band.
+                frequency_band: 0x08,
+                manufacturer_code: 0x1037,
+                maximum_buffer_size: 80,
+                maximum_incoming_transfer_size: 128,
+                server_mask: 0,
+                maximum_outgoing_transfer_size: 128,
+                descriptor_capability_field: 0,
+                ..NodeDescriptorConfig::default()
+            },
+            power: PowerDescriptorConfig {
+                current_power_mode: CurrentPowerMode::Stimulated,
+                available_power_sources: &[PowerSource::DisposableBattery],
+                current_power_source: PowerSource::DisposableBattery,
+                current_power_source_level: CurrentPowerSourceLevel::Full,
+            },
+            endpoints: &ENDPOINTS,
+        },
+    )
 }
 
 /// Parent poll interval; must stay below the parent's ~7.68 s
@@ -147,16 +175,17 @@ const POLL_INTERVAL_MS: u32 = 500;
 /// Identify state, shared between the receive task and the application.
 static IDENTIFY: IdentifyServer = IdentifyServer::new();
 
-/// Receive loop: idles until the join completes, then answers ZDP discovery,
-/// Basic-cluster and Identify reads, Identify commands, Configure Reporting
-/// requests, and APS commands (TC link key exchange).
+/// Drives the stack: receives and answers ZDP discovery, Basic-cluster and
+/// Identify reads, Identify commands, Configure Reporting requests and APS
+/// commands, keeps the parent link alive, and persists NIB/AIB changes.
 #[embassy_executor::task]
-async fn rx_task(device: &'static ZigbeeDevice<EspMlme<'static>>) {
-    let cfg = descriptor_config();
-    let handler = (BASIC, ConfigureReportingServer, &IDENTIFY);
-    device
-        .rx_loop(&cfg, &handler, &mut Delay, POLL_INTERVAL_MS)
-        .await
+async fn stack_task(stack: &'static Stack) {
+    // returns only when no rejoin could get us back onto the network: the
+    // network is gone or our keys are stale, so re-commission from scratch
+    let outcome = stack.run(Delay).await;
+    println!("Off the network ({outcome:?}), forgetting it and rebooting");
+    stack.forget_network().await;
+    esp_hal::system::software_reset();
 }
 
 /// Counts the Identify state down once a second (ZCL 3.5.2.2.1); a real device
@@ -182,128 +211,48 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
 
     esp_alloc::heap_allocator!(size: 24 * 1024);
 
-    // the stack owns persistence: it restores the information bases here and
-    // the storage task persists dirty state (keys, frame counters, tables)
-    // whenever the stack changes it
+    // the stack owns persistence: the information bases are restored here and
+    // the stack persists dirty state (keys, frame counters, tables) whenever it
+    // changes them
     let flash = BlockingAsync::new(FlashStorage::new(peripherals.FLASH));
-    let storage: &'static ZigbeeFlash =
-        STORAGE.init(zigbee::storage::init_with_flash(flash, ZIGBEE_FLASH_RANGE).await);
+    let storage = zigbee::storage::init_with_flash(flash, ZIGBEE_FLASH_RANGE).await;
 
-    // a restored short address means we are still on the network: the parent
-    // keeps sleepy children across our reboot, so resume polling instead of
-    // re-commissioning (NLME-JOIN refuses to re-associate a joined device)
-    let nib = zigbee::nwk::nib::get_ref();
-    let resume = *nib.network_address() != 0xffff;
-
-    // on resume the radio must be configured from the restored NIB up front —
-    // association normally does this, but we skip it
-    let mut mac_config = esp_radio::ieee802154::Config::default();
-    if resume {
-        mac_config.channel = CHANNEL;
-        mac_config.pan_id = Some(*nib.panid());
-        mac_config.short_addr = Some(*nib.network_address());
-        mac_config.auto_ack_tx = true;
-        mac_config.auto_ack_rx = true;
-    }
+    let config = stack_config();
 
     let ieee802154 = Ieee802154::new(peripherals.IEEE802154);
-    let mac = EspMlme::new(ieee802154, mac_config);
+    // the stack programs the radio from the restored information base: on a
+    // reboot while joined it resumes instead of re-commissioning
+    let mac = EspMlme::new(ieee802154, esp_radio::ieee802154::Config::default());
     println!("Device IEEE address: {:#018x}", mac.ieee_address());
-    let nlme = Nlme::new(mac);
 
-    let config = zigbee::Config {
-        device_type: LogicalType::EndDevice,
-        ..zigbee::Config::default()
-    };
-    let device: &'static ZigbeeDevice<EspMlme<'static>> =
-        DEVICE.init(ZigbeeDevice::new(config, nlme));
-    let mut bdb = BaseDeviceBehavior::new(config);
+    let handler = (BASIC, ConfigureReportingServer, &IDENTIFY);
+    let stack: &'static Stack = STACK.init(Stack::new(mac, config, handler, storage));
 
-    // spawn the receive loop up front; it idles until the join completes,
-    // then answers the interview and delivers the TC link key replies
-    spawner.spawn(rx_task(device).expect("spawn rx_task"));
-    // persist NIB/AIB changes as they happen, including the keys obtained
-    // during commissioning
-    spawner.spawn(storage_task(storage).expect("spawn storage_task"));
+    // the stack task is all it takes: it commissions the device, answers the
+    // interview, keeps the parent link alive and persists NIB/AIB changes
+    spawner.spawn(stack_task(stack).expect("spawn stack_task"));
     spawner.spawn(identify_task().expect("spawn identify_task"));
 
-    if resume {
-        println!(
-            "Resuming on network: addr={:#06x} pan={:#06x} channel={CHANNEL}, attempting rejoin...",
-            *nib.network_address(),
-            *nib.panid(),
-        );
+    stack.wait_until_joined().await;
+
+    let nib = zigbee::nwk::nib::get_ref();
+    println!(
+        "On network: addr={:#06x} pan={:#06x} epid={:#x} channel={} update_id={}",
+        *nib.network_address(),
+        *nib.panid(),
+        *nib.extended_panid(),
+        stack.config().channel(),
+        nib.update_id()
+    );
+    if let Some(material) = nib.security_material_set().first() {
+        println!("Network key installed: key={:02x?}", material.key);
     }
-
-    match bdb.start_initialization_procedure(device, &mut Delay).await {
-        Ok(Some(confirm)) if confirm.status == NlmeJoinStatus::Success => {
-            println!(
-                "Rejoined: addr={:#06x} pan={:#06x} channel={CHANNEL}",
-                *nib.network_address(),
-                *nib.panid(),
-            );
-        }
-        init_result => {
-            // a prior rejoin attempt leaves the old network address/key
-            // material in the NIB; forget it before commissioning fresh so
-            // NLME-JOIN's "already joined" check does not reject it
-            if let Ok(Some(confirm)) = init_result {
-                println!("Rejoin failed ({:?}), forgetting network", confirm.status);
-                device.forget_network();
-            }
-
-            println!("Joining EPID={EXTENDED_PAN_ID:#018x} on channel {CHANNEL}...");
-            let join = bdb
-                .network_steering(
-                    device,
-                    &mut Delay,
-                    IeeeAddress(EXTENDED_PAN_ID),
-                    CHANNEL..CHANNEL + 1,
-                    SCAN_DURATION,
-                    CapabilityInformation(CAPABILITY),
-                )
-                .await;
-
-            match join {
-                Ok(confirm) if confirm.status == NlmeJoinStatus::Success => {
-                    let nib = bdb.nib();
-                    println!(
-                        "Joined: addr={:#06x} pan={:#06x} epid={:#x} update_id={}",
-                        *nib.network_address(),
-                        *nib.panid(),
-                        *nib.extended_panid(),
-                        nib.update_id()
-                    );
-
-                    let network_key = nib.security_material_set().first().unwrap().key;
-                    println!("Network key installed: key={:02x?}", network_key);
-
-                    let link_key = aib::get_ref()
-                        .device_key_pair_set()
-                        .first()
-                        .unwrap()
-                        .link_key;
-                    println!("Link key installed: key={:02x?}", link_key);
-                }
-                Ok(confirm) => {
-                    println!("Join failed: {:?}", confirm.status);
-                    loop {
-                        Timer::after_secs(60).await;
-                    }
-                }
-                Err(e) => {
-                    println!("Join error: {e:#}");
-                    loop {
-                        Timer::after_secs(60).await;
-                    }
-                }
-            }
-        }
+    if let Some(pair) = aib::get_ref().device_key_pair_set().first() {
+        println!("Link key installed: key={:02x?}", pair.link_key);
     }
 
     let mut zcl_seq: u8 = 0;
     let mut sample: i16 = 2300; // 23.00 °C in hundredths
-    let mut report_failures: u32 = 0;
     loop {
         zcl_seq = zcl_seq.wrapping_add(1);
 
@@ -316,7 +265,8 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
         )
         .expect("encode temperature report");
 
-        let result = device
+        let result = stack
+            .device()
             .send_zcl_unicast(
                 ZclUnicast {
                     dst_short: ShortAddress::COORDINATOR.0,
@@ -333,41 +283,14 @@ async fn main(spawner: embassy_executor::Spawner) -> ! {
         match result {
             Ok(confirm) if confirm.status == ApsdeSapConfirmStatus::Success => {
                 println!("Reported temperature: {} (seq={})", sample, zcl_seq);
-                report_failures = 0;
             }
-            // only a missing acknowledgement points at an unreachable parent;
-            // the other statuses are local or transient
-            Ok(confirm) => {
-                println!("Report failed: {:?}", confirm.status);
-                if confirm.status == ApsdeSapConfirmStatus::NoAck {
-                    report_failures += 1;
-                }
-            }
+            // a lost parent link is detected by the stack and handled by the
+            // link task; anything reported here is local or transient
+            Ok(confirm) => println!("Report failed: {:?}", confirm.status),
             Err(e) => println!("Encode error: {:?}", e),
-        }
-
-        // an unreachable parent (no MAC ack) means we were likely aged out of
-        // its child table — forget the network and re-commission from scratch
-        if report_failures >= MAX_REPORT_FAILURES {
-            println!("Parent unreachable, forgetting network and rebooting");
-            device.forget_network();
-            // make sure the cleared state hits flash before the reset
-            storage.flush().await;
-            esp_hal::system::software_reset();
         }
 
         sample = sample.wrapping_add(10);
         Timer::after_secs(30).await;
     }
-}
-
-/// consecutive report failures before the network is forgotten and the device
-/// re-commissions.
-const MAX_REPORT_FAILURES: u32 = 4;
-
-/// Persists information-base changes (keys, frame counters, neighbor table)
-/// to flash as the stack makes them.
-#[embassy_executor::task]
-async fn storage_task(storage: &'static ZigbeeFlash) {
-    storage.run().await
 }

--- a/zigbee-app/Cargo.toml
+++ b/zigbee-app/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "zigbee-app"
+version = "0.1.0-alpha.1"
+
+description = "Application-facing runtime for the zigbee stack: receive loop, link maintenance and commissioning policy"
+documentation = "https://docs.rs/zigbee-app"
+readme = "README.md"
+keywords = ["zigbee", "ieee802154", "no-std", "embedded"]
+categories = ["network-programming", "no-std", "embedded"]
+license = "MIT OR Apache-2.0"
+
+authors.workspace = true
+repository.workspace = true
+edition.workspace = true
+
+[features]
+# persist the information bases to NOR flash; re-exports the flash storage
+# driver so an application only depends on this crate
+storage = ["zigbee/storage"]
+
+[dependencies]
+embedded-hal-async.workspace = true
+log.workspace = true
+zigbee = { path = "../zigbee" }
+zigbee-base-device-behavior = { version = "0.1.0-alpha.1", path = "../zigbee-base-device-behavior" }
+zigbee-mac = { version = "0.1.0", path = "../zigbee-mac" }
+zigbee-types = { version = "0.1.0", path = "../zigbee-types" }

--- a/zigbee-app/README.md
+++ b/zigbee-app/README.md
@@ -1,0 +1,22 @@
+# zigbee-app
+
+Application-facing runtime for the [`zigbee`](../zigbee) stack.
+
+The layers below implement the specification and nothing else. This crate holds
+the behavior the specs deliberately leave to the implementer, so an application
+does not have to reinvent it:
+
+| Function | What it decides |
+|----------|-----------------|
+| `commission` | startup order: resume, rejoin, or steer onto a network |
+| `rx_loop` | receive/dispatch strategy and poll cadence |
+| `link_maintenance` | keepalive period (3.6.10.3) and how to recover a lost parent link |
+| `keepalive` | one keepalive, when the loop is driven elsewhere |
+
+`rx_loop` and `link_maintenance` are meant to run as two tasks sharing a
+`&'static ZigbeeDevice`.
+
+## License
+
+Licensed under either of Apache License, Version 2.0 or MIT license at your
+option.

--- a/zigbee-app/src/config.rs
+++ b/zigbee-app/src/config.rs
@@ -1,0 +1,129 @@
+//! Everything an application configures, in one place.
+//!
+//! The layers below take their own spec-shaped configuration — `zigbee::Config`
+//! for the ZDO, `DeviceDescriptorConfig` for the descriptors an interviewer
+//! asks for — and several values appear in more than one of them: the logical
+//! device type, the MAC capability byte, the operating channel. [`StackConfig`]
+//! is the single source for those, deriving the per-layer configuration from
+//! it so the copies cannot drift apart.
+
+use zigbee::nwk::nib::CapabilityInformation;
+use zigbee::zdo::config::DiscoveryType;
+use zigbee::zdo::descriptor::DeviceDescriptorConfig;
+use zigbee_types::IeeeAddress;
+
+/// The network this device belongs to.
+pub struct NetworkConfig {
+    /// Extended PAN id to join, rejoin, or steer onto.
+    pub extended_pan_id: IeeeAddress,
+    /// Channels scanned when joining, and when looking for a new parent
+    /// (3.6.1.4.2). The first one is the operating channel.
+    pub channels: core::ops::Range<u8>,
+    /// Scan duration exponent used for those scans.
+    pub scan_duration: u8,
+}
+
+/// What this device is on that network.
+pub struct DeviceConfig {
+    /// Coordinator, router, or end device.
+    pub logical_type: zigbee::LogicalType,
+    /// Capability information this device joins with (Table 3-62); its
+    /// receiver-on-when-idle bit also decides how [`crate::rx_loop`] receives.
+    pub capability_information: CapabilityInformation,
+    /// How this device discovers addresses of others (2.4.3.1).
+    pub discovery_type: DiscoveryType,
+    /// Whether commissioning exchanges the initial Trust Center link key for a
+    /// unique one (BDB 8.2 step 12). Disable for trust centers that never
+    /// answer the request and would only stall the join.
+    pub tc_link_key_exchange: bool,
+}
+
+/// Cadences the specification leaves to the implementer.
+pub struct TimingConfig {
+    /// How often a sleepy end device polls its parent for buffered frames.
+    /// Keep it below the parent's indirect-transaction persistence time
+    /// (~7.68 s).
+    pub poll_interval_ms: u32,
+    /// Keepalive period used until one is negotiated with the parent
+    /// (3.6.10.3 leaves the period to the manufacturer); the negotiated
+    /// timeout takes over as soon as there is one.
+    pub default_keepalive_interval_ms: u32,
+}
+
+impl Default for TimingConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval_ms: 1_000,
+            default_keepalive_interval_ms: 60_000,
+        }
+    }
+}
+
+/// The whole application-facing configuration of the stack.
+///
+/// Build it once with [`StackConfig::new`] and hand it to every entry point of
+/// this crate; [`Self::zdo`] produces the configuration
+/// [`zigbee::ZigbeeDevice`] and BDB expect.
+pub struct StackConfig<'a> {
+    network: NetworkConfig,
+    device: DeviceConfig,
+    timing: TimingConfig,
+    descriptors: DeviceDescriptorConfig<'a>,
+}
+
+impl<'a> StackConfig<'a> {
+    /// Assemble the configuration, deriving what the descriptors would
+    /// otherwise duplicate: the node descriptor's logical type and MAC
+    /// capability flags always match the ones the device joins with.
+    pub fn new(
+        network: NetworkConfig,
+        device: DeviceConfig,
+        timing: TimingConfig,
+        descriptors: DeviceDescriptorConfig<'a>,
+    ) -> Self {
+        let mut descriptors = descriptors;
+        descriptors.node.logical_type = device.logical_type;
+        descriptors.node.mac_capability_flags = device.capability_information.0;
+        Self {
+            network,
+            device,
+            timing,
+            descriptors,
+        }
+    }
+
+    /// The network this device belongs to.
+    pub fn network(&self) -> &NetworkConfig {
+        &self.network
+    }
+
+    /// What this device is on that network.
+    pub fn device(&self) -> &DeviceConfig {
+        &self.device
+    }
+
+    /// The configured cadences.
+    pub fn timing(&self) -> &TimingConfig {
+        &self.timing
+    }
+
+    /// The descriptors served to an interviewer (2.3.2).
+    pub fn descriptors(&self) -> &DeviceDescriptorConfig<'a> {
+        &self.descriptors
+    }
+
+    /// The operating channel: the first of the configured channels.
+    pub fn channel(&self) -> u8 {
+        self.network.channels.start
+    }
+
+    /// The ZDO configuration derived from this one, for
+    /// [`zigbee::ZigbeeDevice::new`] and `BaseDeviceBehavior::new`.
+    pub fn zdo(&self) -> zigbee::Config {
+        zigbee::Config {
+            radio_channel: self.channel(),
+            device_discovery_type: self.device.discovery_type,
+            device_type: self.device.logical_type,
+        }
+    }
+}

--- a/zigbee-app/src/lib.rs
+++ b/zigbee-app/src/lib.rs
@@ -1,0 +1,49 @@
+//! Application-facing runtime for the zigbee stack.
+//!
+//! The layers below implement the specification and nothing else: the NWK
+//! layer owns the keepalive primitives and the rejoin procedure (3.6.10,
+//! 3.6.1.4.2), the ZDO owns the Network Manager's rejoin-when-communication-
+//! is-lost duty (2.5.2.4), and BDB owns the commissioning procedures. What
+//! none of them define is *when* to run those procedures: 3.6.10.3 leaves the
+//! keepalive period to the manufacturer, and the order in which a device
+//! resumes, rejoins, or re-commissions at startup is an application decision.
+//!
+//! This crate holds exactly that policy. An application describes itself once
+//! with a [`StackConfig`], builds a [`Stack`] on top of its MAC, and spawns
+//! the loops against it:
+//!
+//! ```ignore
+//! let stack = STACK.init(Stack::new(mac, config, handler, storage));
+//! spawner.spawn(stack_task(stack));  // stack.run(Delay): commission, then stay on
+//! stack.wait_until_joined().await;   // ready to talk to the network
+//! ```
+//!
+//! [`Stack::run`] is the only task the stack needs: it commissions the device,
+//! then drives the receive loop, link maintenance and persistence together.
+//! Every other task borrows the same [`Stack`] to talk to the network. Drive
+//! the parts separately with [`Stack::commission`], [`Stack::rx_loop`] and
+//! [`Stack::link_maintenance`] if they need tasks of their own.
+#![no_std]
+
+pub mod config;
+pub mod stack;
+
+pub use config::DeviceConfig;
+pub use config::NetworkConfig;
+pub use config::StackConfig;
+pub use config::TimingConfig;
+pub use stack::Commissioned;
+pub use stack::Stack;
+pub use stack::StackStopped;
+/// Flash-backed persistence (feature `storage`): restore the information bases
+/// with [`init_with_flash`], then hand the driver to [`Stack::new`].
+#[cfg(feature = "storage")]
+pub use zigbee::storage::FlashStorage;
+/// RAM-only persistence: pass it to [`Stack::new`] when state need not survive
+/// a reset.
+pub use zigbee::storage::NoStorage;
+#[cfg(feature = "storage")]
+pub use zigbee::storage::init_with_flash;
+/// The commissioning procedures the stack runs, reachable via
+/// [`Stack::bdb`] for the ones it does not run itself.
+pub use zigbee_base_device_behavior::BaseDeviceBehavior;

--- a/zigbee-app/src/stack.rs
+++ b/zigbee-app/src/stack.rs
@@ -1,0 +1,394 @@
+//! The runtime object an application spawns its tasks against.
+
+use core::future::Future;
+use core::pin::pin;
+use core::task::Poll;
+use core::task::ready;
+
+use embedded_hal_async::delay::DelayNs;
+use zigbee::nwk::frame::command::network_status::NetworkStatusCode;
+use zigbee::nwk::nib;
+use zigbee::nwk::nlme::KeepaliveMethod;
+use zigbee::nwk::nlme::NetworkError;
+use zigbee::nwk::nlme::Nlme;
+use zigbee::nwk::nlme::management::NlmeJoinConfirm;
+use zigbee::nwk::nlme::management::NlmeJoinStatus;
+use zigbee::storage::NoStorage;
+use zigbee::storage::StorageDriver;
+use zigbee::zdo::ClusterRequestHandler;
+use zigbee::zdo::ZigbeeDevice;
+use zigbee_base_device_behavior::BaseDeviceBehavior;
+use zigbee_mac::mlme::Mlme;
+use zigbee_types::ShortAddress;
+
+use crate::config::StackConfig;
+
+/// How [`Stack::commission`] got the device onto the network.
+#[derive(Debug)]
+pub enum Commissioned {
+    /// The device rejoined the network it was already on (BDB 7.1).
+    Rejoined(NlmeJoinConfirm),
+    /// The device joined and was commissioned from scratch (BDB 8.2).
+    Steered(NlmeJoinConfirm),
+    /// Neither rejoining nor steering got the device onto a network.
+    Failed(NlmeJoinStatus),
+}
+
+/// Why [`Stack::run`] returned: the device is off the network and could not
+/// get back on by itself.
+#[derive(Debug)]
+pub enum StackStopped {
+    /// Commissioning could not put the device onto a network (BDB 8.2).
+    Commissioning(NlmeJoinStatus),
+    /// The network was lost and no rejoin got the device back (3.6.10.10).
+    Rejoin(NlmeJoinStatus),
+    /// A layer below reported an error.
+    Error(NetworkError),
+}
+
+/// The running stack: the device, its configuration, the cluster handler
+/// answering inbound requests, and where state is persisted.
+///
+/// Build it once, keep it alive for the program (a `StaticCell` does), and
+/// spawn [`Self::run`] in a task; every other task borrows the same instance
+/// to talk to the network.
+pub struct Stack<'d, M, H, S = NoStorage> {
+    device: ZigbeeDevice<M>,
+    config: StackConfig<'d>,
+    handler: H,
+    storage: S,
+    bdb: BaseDeviceBehavior,
+}
+
+impl<'d, M, H, S> Stack<'d, M, H, S>
+where
+    M: Mlme,
+    H: ClusterRequestHandler,
+    S: StorageDriver,
+{
+    /// Build the stack on top of a MAC.
+    ///
+    /// The information bases must already be restored (`zigbee::storage`),
+    /// because the NWK layer reads them here.
+    pub fn new(mac: M, config: StackConfig<'d>, handler: H, storage: S) -> Self {
+        let device = ZigbeeDevice::new(config.zdo(), Nlme::new(mac));
+        let bdb = BaseDeviceBehavior::new(config.zdo());
+        bdb.set_tc_link_key_exchange(config.device().tc_link_key_exchange);
+        Self {
+            device,
+            config,
+            handler,
+            storage,
+            bdb,
+        }
+    }
+
+    /// Run the stack: get onto the network, then stay on it.
+    ///
+    /// Commissions the device first (resume, rejoin, or steer onto the
+    /// configured network), then keeps the parent link alive, all while
+    /// receiving and dispatching inbound frames and persisting
+    /// information-base changes. The application only has to spawn this.
+    ///
+    /// Returns when the device is off the network and cannot get back on, so
+    /// the caller can decide between re-commissioning and a reset; use
+    /// [`Self::wait_until_joined`] to learn when the device is on the network
+    /// instead of waiting for this.
+    pub async fn run<D: DelayNs + Clone>(&self, delay: D) -> StackStopped {
+        self.resume().await;
+        let mut rx_delay = delay.clone();
+        let mut main_delay = delay;
+
+        // the receive loop has to run during commissioning: it idles until the
+        // join completes, then delivers the Trust Center's replies
+        let receive = async { self.rx_loop(&mut rx_delay).await };
+        let persist = self.storage.run();
+        let network = async {
+            match self.commission(&mut main_delay).await {
+                Ok(Commissioned::Rejoined(_) | Commissioned::Steered(_)) => (),
+                Ok(Commissioned::Failed(status)) => {
+                    return StackStopped::Commissioning(status);
+                }
+                Err(e) => return StackStopped::Error(e),
+            }
+
+            match self.link_maintenance(&mut main_delay).await {
+                Ok(confirm) => StackStopped::Rejoin(confirm.status),
+                Err(e) => StackStopped::Error(e),
+            }
+        };
+
+        drive(network, receive, persist).await
+    }
+}
+
+// polls `main` to completion while the background futures keep running
+async fn drive<T>(
+    main: impl Future<Output = T>,
+    background: impl Future<Output = ()>,
+    persist: impl Future<Output = ()>,
+) -> T {
+    let mut main = pin!(main);
+    let mut background = pin!(background);
+    let mut persist = pin!(persist);
+    core::future::poll_fn(move |cx| {
+        let _ = background.as_mut().poll(cx);
+        let _ = persist.as_mut().poll(cx);
+        Poll::Ready(ready!(main.as_mut().poll(cx)))
+    })
+    .await
+}
+
+impl<'d, M, H, S> Stack<'d, M, H, S>
+where
+    M: Mlme,
+    H: ClusterRequestHandler,
+    S: StorageDriver,
+{
+    /// The device this stack drives, for everything the application sends and
+    /// asks itself (APSDE-SAP, binding, leaving).
+    pub fn device(&self) -> &ZigbeeDevice<M> {
+        &self.device
+    }
+
+    /// The configuration this stack runs with.
+    pub fn config(&self) -> &StackConfig<'d> {
+        &self.config
+    }
+
+    /// The BDB commissioning manager, for procedures the stack does not run
+    /// itself — network formation, finding & binding, touchlink — and for the
+    /// commissioning status (BDB 5.3.1).
+    ///
+    /// Commissioning procedures are not meant to overlap: do not start one
+    /// while [`Self::run`] is commissioning.
+    pub fn bdb(&self) -> &BaseDeviceBehavior {
+        &self.bdb
+    }
+
+    /// Program the radio from the restored information base (3.6.8).
+    ///
+    /// A device reset while joined keeps its addresses but comes up with an
+    /// unconfigured radio; this applies the PAN id, short address and channel
+    /// so it can resume where it left off instead of re-commissioning.
+    /// [`Self::run`] and [`Self::commission`] do this for you.
+    pub async fn resume(&self) -> bool {
+        let resuming = self.device.nlme().resume(self.config.channel()).await;
+        if resuming {
+            log::info!(
+                "[APP] resuming on network: addr={:#06x}",
+                *nib::get_ref().network_address()
+            );
+        }
+        resuming
+    }
+
+    /// Wait until the device is on the network with the network key
+    /// installed, so the application can start talking to it.
+    pub async fn wait_until_joined(&self) {
+        self.device.wait_until_joined().await;
+    }
+
+    /// Forget the joined network and persist that, so the next boot
+    /// re-commissions instead of resuming.
+    pub async fn forget_network(&self) {
+        self.device.forget_network();
+        self.storage.flush().await;
+    }
+
+    /// Bring the device onto its network at startup.
+    ///
+    /// Runs the BDB initialization procedure first (7.1): a device that is
+    /// still on a network rejoins it, keeping its keys. If that fails, the
+    /// remembered network is forgotten and network steering commissions the
+    /// device from scratch (BDB 8.2). [`Self::run`] does this for you; call it
+    /// directly only when driving the stack's loops as separate tasks, and make
+    /// sure [`Self::rx_loop`] is already running — it delivers the Trust
+    /// Center's replies.
+    pub async fn commission(&self, delay: &mut impl DelayNs) -> Result<Commissioned, NetworkError> {
+        self.resume().await;
+        let device = &self.device;
+        let config = &self.config;
+        let bdb = &self.bdb;
+        match bdb.start_initialization_procedure(device, delay).await? {
+            Some(confirm) if confirm.status == NlmeJoinStatus::Success => {
+                return Ok(Commissioned::Rejoined(confirm));
+            }
+            // on a network but unable to rejoin: the stale address and keys would
+            // make NLME-JOIN refuse to re-associate, so drop them first
+            Some(confirm) => {
+                log::warn!(
+                    "[APP] rejoin failed ({:?}), forgetting network",
+                    confirm.status
+                );
+                device.forget_network();
+            }
+            // not on a network at all
+            None => (),
+        }
+
+        let network = config.network();
+        let confirm = bdb
+            .network_steering(
+                device,
+                delay,
+                network.extended_pan_id,
+                network.channels.clone(),
+                network.scan_duration,
+                config.device().capability_information,
+            )
+            .await?;
+
+        if confirm.status == NlmeJoinStatus::Success {
+            Ok(Commissioned::Steered(confirm))
+        } else {
+            Ok(Commissioned::Failed(confirm.status))
+        }
+    }
+
+    /// Run the receive/dispatch loop forever.
+    ///
+    /// Waits for the join to complete before touching the radio, so it can be
+    /// started ahead of commissioning. The receive strategy follows the joined
+    /// capability (`nwkCapabilityInformation`, 3.4.1.3.1.1): a device with
+    /// `rxOnWhenIdle = TRUE` listens for frames directly, while a sleepy end
+    /// device polls its parent every `poll_interval_ms`.
+    ///
+    /// A leave takes the device off the network and parks the loop until it is
+    /// back on. [`Self::run`] drives this for you.
+    pub async fn rx_loop(&self, delay: &mut impl DelayNs) -> ! {
+        let device = &self.device;
+        let handler = &self.handler;
+        let cfg = self.config.descriptors();
+        // a restored network address means the device resumed on a network without
+        // a fresh key exchange — release the gate immediately
+        if *nib::get_ref().network_address() != ShortAddress::default().0 {
+            device.mark_rejoined();
+        }
+        device.wait_until_joined().await;
+
+        if nib::get_ref()
+            .capability_information()
+            .receiver_on_when_idle()
+        {
+            loop {
+                // dispatching a leave closes the gate again, parking the loop
+                // until the device has been rejoined or re-commissioned
+                device.wait_until_joined().await;
+                if let Err(e) = device.receive_and_dispatch(cfg, handler).await {
+                    log::debug!("[APP] rx dispatch error: {e:?}");
+                }
+            }
+        }
+
+        loop {
+            device.wait_until_joined().await;
+            match device.poll_and_dispatch(cfg, handler).await {
+                // an acknowledged data poll shows the parent still holds this
+                // device in its neighbor table (3.6.10.4)
+                Ok(()) => {
+                    if device.nlme().keepalive_method() == KeepaliveMethod::MacDataPoll {
+                        device.nlme().refresh_parent_timeout();
+                    }
+                }
+                Err(e) => log::debug!("[APP] rx dispatch error: {e:?}"),
+            }
+            delay.delay_ms(self.config.timing().poll_interval_ms).await;
+        }
+    }
+
+    /// Keep the parent link alive and rejoin whenever it is lost.
+    ///
+    /// Sends the periodic end-device keepalive (3.6.10.3) — for sleepy and
+    /// `rxOnWhenIdle` devices alike — and reacts to everything that takes this
+    /// device off the network: a failed keepalive, an expired local end-device
+    /// timeout (3.6.10.6), a failed parent link reported while sending
+    /// (3.6.3.7.1), and a leave asking the device to come back (3.6.1.10.4).
+    /// Recovery is [`ZigbeeDevice::rejoin`], which keeps the keys.
+    ///
+    /// Returns only when the device is off the network for good.
+    /// [`Self::run`] drives this for you.
+    pub async fn link_maintenance(
+        &self,
+        delay: &mut impl DelayNs,
+    ) -> Result<NlmeJoinConfirm, NetworkError> {
+        let device = &self.device;
+        let config = &self.config;
+        loop {
+            let interval = device
+                .nlme()
+                .keepalive_interval_ms()
+                .unwrap_or(config.timing().default_keepalive_interval_ms);
+            delay.delay_ms(interval).await;
+
+            // the error already covers a drained local end-device timeout
+            let keepalive_failed = self.keepalive().await.is_err();
+            let parent_link_failed = matches!(
+                device.nlme().take_nwk_status_indication(),
+                Some(indication) if indication.status == NetworkStatusCode::ParentLinkFailure
+            );
+            let rejoin_requested = device.take_rejoin_request();
+
+            if !(keepalive_failed || parent_link_failed || rejoin_requested) {
+                continue;
+            }
+
+            log::info!(
+                "[APP] parent link lost (keepalive={keepalive_failed}, status={parent_link_failed}, leave={rejoin_requested}), rejoining"
+            );
+            let network = config.network();
+            let confirm = device
+                .rejoin(
+                    network.extended_pan_id,
+                    network.channels.clone(),
+                    network.scan_duration,
+                )
+                .await?;
+            if confirm.status != NlmeJoinStatus::Success {
+                return Ok(confirm);
+            }
+        }
+    }
+
+    /// Send one keepalive to the parent (3.6.10.3).
+    ///
+    /// Every end device — sleepy or `rxOnWhenIdle` — refreshes its entry in
+    /// the parent's neighbor table this way, using the method the parent
+    /// announced: a MAC data poll, whose retrieved frame is dispatched like in
+    /// [`Self::rx_loop`], or an End Device Timeout Request. Without a
+    /// negotiated timeout there is nothing to send and it succeeds silently.
+    ///
+    /// `Err(NetworkError::ParentLinkFailure)` means the link is gone — the
+    /// parent rejected or ignored a timeout request, or enough keepalives went
+    /// unanswered to run out the local end-device timeout (3.6.10.6).
+    pub async fn keepalive(&self) -> Result<(), NetworkError> {
+        let device = &self.device;
+        let handler = &self.handler;
+        let nlme = device.nlme();
+        let cfg = self.config.descriptors();
+        let result = match nlme.keepalive_method() {
+            // the data poll itself is the keepalive, so dispatch what it brings
+            // back instead of dropping it
+            KeepaliveMethod::MacDataPoll => {
+                let result = device.poll_and_dispatch(cfg, handler).await;
+                if result.is_ok() {
+                    nlme.refresh_parent_timeout();
+                }
+                result
+            }
+            KeepaliveMethod::TimeoutRequest | KeepaliveMethod::None => nlme.send_keepalive().await,
+        };
+        let Err(e) = result else {
+            return Ok(());
+        };
+
+        // 3.6.10.6: an unanswered keepalive drains the local timeout, so a single
+        // missed one does not yet count as a lost parent
+        log::warn!("[APP] keepalive failed: {e:?}");
+        let interval = nlme.keepalive_interval_ms().unwrap_or(0);
+        if nlme.tick_parent_timeout(interval) {
+            return Err(NetworkError::ParentLinkFailure);
+        }
+        Err(e)
+    }
+}

--- a/zigbee-base-device-behavior/Cargo.toml
+++ b/zigbee-base-device-behavior/Cargo.toml
@@ -15,6 +15,7 @@ edition.workspace = true
 
 [dependencies]
 embedded-hal-async.workspace = true
+spin.workspace = true
 thiserror.workspace = true
 log.workspace = true
 zigbee = { path = "../zigbee" }

--- a/zigbee-base-device-behavior/src/lib.rs
+++ b/zigbee-base-device-behavior/src/lib.rs
@@ -5,10 +5,10 @@
 //!
 //! This crate defines the standard commissioning procedures all devices must
 //! support. It is a thin commissioning orchestrator: it does not own the
-//! [`ZigbeeDevice`] or the [`Nlme`] — instead, callers pass them by mutable
-//! reference for the duration of a commissioning procedure. Post-commissioning
-//! the application interacts with the stack through the APSDE-SAP exposed on
-//! [`ZigbeeDevice`].
+//! [`ZigbeeDevice`] or the [`Nlme`] — instead, callers pass the device to a
+//! commissioning procedure. Everything takes `&self`, like the layers below,
+//! so one instance can be shared; post-commissioning the application interacts
+//! with the stack through the APSDE-SAP exposed on [`ZigbeeDevice`].
 #![no_std]
 #![allow(unused)]
 
@@ -18,9 +18,12 @@ extern crate std;
 use core::future::Future;
 use core::future::poll_fn;
 use core::pin::pin;
+use core::sync::atomic::AtomicBool;
+use core::sync::atomic::Ordering;
 use core::task::Poll;
 
 use embedded_hal_async::delay::DelayNs;
+use spin::Mutex;
 use thiserror::Error;
 
 pub mod types;
@@ -62,7 +65,7 @@ use zigbee::nwk::nlme::management::RejoinNetwork;
 use zigbee::security::primitives::HmacAes128Mmo;
 use zigbee::zdo::ZigbeeDevice;
 use zigbee::zdo::descriptor::NodeDescRsp;
-use zigbee::zdp::device_annce::DeviceAnnce;
+use zigbee_mac::mlme::MacConfig;
 use zigbee_mac::mlme::Mlme;
 use zigbee_types::ByteArray;
 use zigbee_types::IeeeAddress;
@@ -74,36 +77,71 @@ use zigbee_types::sync::with_timeout;
 /// Orchestrates the standard commissioning procedures defined in the BDB
 /// specification: initialization, network steering, network formation,
 /// finding & binding, and touchlink. The application owns the
-/// [`ZigbeeDevice`] and the [`Nlme`]; commissioning methods borrow them
+/// [`ZigbeeDevice`] and the [`Nlme`]; commissioning methods borrow the device
 /// for the duration of the procedure.
+///
+/// Like the layers below, procedures take `&self` and keep their few
+/// attributes (BDB 5.3) behind interior mutability, so one instance can be
+/// shared. They are not meant to overlap, though: run one commissioning
+/// procedure at a time.
 pub struct BaseDeviceBehavior {
     config: Config,
-    bdb_node_is_on_a_network: bool,
-    bdb_commissioning_mode: CommissioningMode,
-    bdb_commissioning_status: BdbCommissioningStatus,
-    /// Whether network steering performs the TC link key exchange (BDB 8.2
-    /// step 12); a failed exchange takes the node off the network again.
-    ///
-    /// Disable to stay on the default global TC link key with a trust center
-    /// that answers neither Node_Desc_req nor REQUEST-KEY, at the cost of
-    /// leaving the join unauthenticated.
-    pub tc_link_key_exchange_enabled: bool,
+    // bdbNodeIsOnANetwork (BDB 5.3.9)
+    bdb_node_is_on_a_network: AtomicBool,
+    // bdbCommissioningMode (BDB 5.3.5)
+    bdb_commissioning_mode: Mutex<CommissioningMode>,
+    // bdbCommissioningStatus (BDB 5.3.1)
+    bdb_commissioning_status: Mutex<BdbCommissioningStatus>,
+    // whether network steering exchanges the TC link key (BDB 8.2 step 12)
+    tc_link_key_exchange_enabled: AtomicBool,
 }
 
 impl BaseDeviceBehavior {
     pub fn new(config: Config) -> Self {
         Self {
             config,
-            bdb_node_is_on_a_network: false,
-            bdb_commissioning_mode: CommissioningMode::NetworkSteering,
-            bdb_commissioning_status: BdbCommissioningStatus::Success,
-            tc_link_key_exchange_enabled: true,
+            bdb_node_is_on_a_network: AtomicBool::new(false),
+            bdb_commissioning_mode: Mutex::new(CommissioningMode::NetworkSteering),
+            bdb_commissioning_status: Mutex::new(BdbCommissioningStatus::Success),
+            tc_link_key_exchange_enabled: AtomicBool::new(true),
         }
     }
 
     /// Returns a reference to the global NIB singleton.
     pub fn nib(&self) -> &'static Nib {
         nib::get_ref()
+    }
+
+    /// bdbCommissioningStatus (BDB 5.3.1): how the last commissioning
+    /// procedure ended, or `InProgress` while one runs.
+    pub fn commissioning_status(&self) -> BdbCommissioningStatus {
+        *self.bdb_commissioning_status.lock()
+    }
+
+    /// bdbCommissioningMode (BDB 5.3.5): the procedure commissioning runs.
+    pub fn commissioning_mode(&self) -> CommissioningMode {
+        *self.bdb_commissioning_mode.lock()
+    }
+
+    /// bdbNodeIsOnANetwork (BDB 5.3.9): whether the node is on a network.
+    pub fn node_is_on_a_network(&self) -> bool {
+        self.bdb_node_is_on_a_network.load(Ordering::Relaxed)
+    }
+
+    /// Whether network steering exchanges the initial Trust Center link key
+    /// for a unique one (BDB 8.2 step 12); a failed exchange takes the node
+    /// off the network again.
+    ///
+    /// Disable to stay on the default global TC link key with a trust center
+    /// that answers neither Node_Desc_req nor REQUEST-KEY, at the cost of
+    /// leaving the join unauthenticated.
+    pub fn set_tc_link_key_exchange(&self, enabled: bool) {
+        self.tc_link_key_exchange_enabled
+            .store(enabled, Ordering::Relaxed);
+    }
+
+    fn set_commissioning_status(&self, status: BdbCommissioningStatus) {
+        *self.bdb_commissioning_status.lock() = status;
     }
 
     /// Initialization procedure (BDB 7.1).
@@ -114,19 +152,23 @@ impl BaseDeviceBehavior {
     /// returns `Ok(None)` and the caller should invoke
     /// [`Self::network_steering`].
     ///
-    /// A rejoin failure is not retried here — the caller is responsible for
+    /// Step 4 delegates to [`ZigbeeDevice::rejoin`], so a Trust Center rejoin
+    /// backs up the secure one. If both fail the caller is responsible for
     /// falling back to [`Self::network_steering`] after
-    /// [`ZigbeeDevice::forget_network`].
+    /// [`ZigbeeDevice::forget_network`]; keeping the parent link alive
+    /// afterwards is [`ZigbeeDevice::link_maintenance`].
     pub async fn start_initialization_procedure<M: Mlme>(
-        &mut self,
+        &self,
         device: &ZigbeeDevice<M>,
         delay: &mut impl DelayNs,
     ) -> Result<Option<NlmeJoinConfirm>, NetworkError> {
         let nib = self.nib();
 
         // BDB 7.1 step 2
-        self.bdb_node_is_on_a_network = *nib.network_address() != 0xffff;
-        if !self.bdb_node_is_on_a_network {
+        let on_a_network = *nib.network_address() != 0xffff;
+        self.bdb_node_is_on_a_network
+            .store(on_a_network, Ordering::Relaxed);
+        if !on_a_network {
             return Ok(None);
         }
 
@@ -137,29 +179,19 @@ impl BaseDeviceBehavior {
             return Ok(None);
         }
 
-        // BDB 7.1 step 4
+        // BDB 7.1 step 4: rejoin on the current channel, so no scan channels
         log::debug!("[BDB] step 4: attempt NWK rejoin");
-        let capability_information = *nib.capability_information();
-        let request = NlmeJoinRequest {
-            extended_pan_id: IeeeAddress(*nib.extended_panid()),
-            rejoin_network: RejoinNetwork::NwkRejoin,
-            capability_information,
-            security_enabled: true,
-        };
-        let confirm = device.nlme().join(request).await;
+        let confirm = device
+            .rejoin(IeeeAddress(*nib.extended_panid()), 0..0, 0)
+            .await?;
 
         // BDB 7.1 step 5
         if confirm.status == NlmeJoinStatus::Success {
-            // 3.6.10.2: the timeout is renegotiated after every rejoin, even
-            // with the same parent
-            Self::negotiate_end_device_timeout(device, delay).await;
-
-            log::debug!("[BDB] step 5: rejoin succeeded, broadcasting Device_annce");
-            Self::device_annce(device, capability_information).await?;
-            self.bdb_commissioning_status = BdbCommissioningStatus::Success;
+            log::debug!("[BDB] step 5: rejoin succeeded");
+            self.set_commissioning_status(BdbCommissioningStatus::Success);
         } else {
             log::warn!("[BDB] step 5: rejoin failed ({:?})", confirm.status);
-            self.bdb_commissioning_status = BdbCommissioningStatus::NoNetwork;
+            self.set_commissioning_status(BdbCommissioningStatus::NoNetwork);
         }
 
         Ok(Some(confirm))
@@ -174,7 +206,7 @@ impl BaseDeviceBehavior {
     /// until the join completes (`ZigbeeDevice::rx_loop`), then delivers the
     /// Trust Center's replies for the link key exchange.
     pub async fn network_steering<M: Mlme>(
-        &mut self,
+        &self,
         device: &ZigbeeDevice<M>,
         delay: &mut impl DelayNs,
         extended_pan_id: IeeeAddress,
@@ -185,7 +217,7 @@ impl BaseDeviceBehavior {
         log::debug!(
             "[BDB] start network steering, EPID={extended_pan_id:?}, channels={channels:?}"
         );
-        self.bdb_commissioning_status = BdbCommissioningStatus::InProgress;
+        self.set_commissioning_status(BdbCommissioningStatus::InProgress);
 
         // a node steering onto a network holds no valid link keys for it: any
         // left over from an earlier network would reject the Trust Center's
@@ -204,10 +236,14 @@ impl BaseDeviceBehavior {
             rejoin_network: RejoinNetwork::Association,
             capability_information,
             security_enabled: false,
+            // an association join selects its parent from the neighbor table
+            // filled by the discovery above
+            scan_channels: 0..0,
+            scan_duration: 0,
         };
         let confirm = device.nlme().join(request).await;
         if confirm.status != NlmeJoinStatus::Success {
-            self.bdb_commissioning_status = BdbCommissioningStatus::NoNetwork;
+            self.set_commissioning_status(BdbCommissioningStatus::NoNetwork);
             return Ok(confirm);
         }
 
@@ -217,21 +253,22 @@ impl BaseDeviceBehavior {
         log::debug!("[BDB] step 9: network key installed");
 
         // 3.6.10.2: negotiate the end-device timeout with the parent
-        Self::negotiate_end_device_timeout(device, delay).await;
+        let _ = device.nlme().negotiate_end_device_timeout().await;
 
         // BDB 8.2 step 11
         log::debug!("[BDB] step 11: broadcast Device_annce");
-        Self::device_annce(device, capability_information).await?;
+        device.announce_self().await?;
 
         // BDB 8.2 step 12, BDB 10.2.5
-        if self.tc_link_key_exchange_enabled {
+        if self.tc_link_key_exchange_enabled.load(Ordering::Relaxed) {
             log::debug!("[BDB] step 12: TC link key exchange");
             // BDB 8.2 step 12: staying on the network with an unexchanged key
             // is not permitted — the node leaves and resets its network state
             if let Err(e) = self.tc_link_key_exchange(device, delay).await {
                 log::warn!("[BDB] step 12: TC link key exchange failed ({e:?}), leaving network");
-                self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
-                self.bdb_node_is_on_a_network = false;
+                self.set_commissioning_status(BdbCommissioningStatus::TclkExFailure);
+                self.bdb_node_is_on_a_network
+                    .store(false, Ordering::Relaxed);
                 let status = device.leave_network(false).await;
                 log::info!("[BDB] left the network after TCLK failure: {status:?}");
                 return Err(e);
@@ -241,55 +278,16 @@ impl BaseDeviceBehavior {
             log::debug!("[BDB] step 12: TC link key exchange disabled, skipping");
         }
 
-        self.bdb_node_is_on_a_network = true;
-        self.bdb_commissioning_status = BdbCommissioningStatus::Success;
+        self.bdb_node_is_on_a_network.store(true, Ordering::Relaxed);
+        self.set_commissioning_status(BdbCommissioningStatus::Success);
         Ok(confirm)
-    }
-
-    // broadcast a ZDO Device_annce (2.4.3.1.11, BDB 8.2 step 11)
-    async fn device_annce<M: Mlme>(
-        device: &ZigbeeDevice<M>,
-        capability_information: CapabilityInformation,
-    ) -> Result<(), NetworkError> {
-        let nib = nib::get_ref();
-        let annce = DeviceAnnce {
-            nwk_addr: ShortAddress(*nib.network_address()),
-            ieee_addr: *nib.ieee_address(),
-            capability: capability_information,
-        };
-        device.device_annce(annce).await
-    }
-
-    // negotiate the end-device timeout with the parent (3.6.10.2); non-fatal
-    // if a legacy parent never answers, it keeps its default timeout
-    async fn negotiate_end_device_timeout<M: Mlme>(
-        device: &ZigbeeDevice<M>,
-        delay: &mut impl DelayNs,
-    ) {
-        log::debug!("[BDB] negotiate end-device timeout");
-        if let Err(e) = device.nlme().send_end_device_timeout_request().await {
-            log::warn!("[BDB] end-device timeout request failed ({e:?})");
-            return;
-        }
-
-        // bounded wait for the receive loop to consume the response
-        let nib = nib::get_ref();
-        for _ in 0..3 {
-            if device.nlme().negotiated_poll_interval_ms().is_some()
-                || *nib.parent_information() != 0
-            {
-                return;
-            }
-            delay.delay_ms(500).await;
-        }
-        log::warn!("[BDB] no end-device timeout response, assuming legacy parent");
     }
 
     // TC link key exchange procedure (BDB 10.2.5): REQUEST-KEY ->
     // TRANSPORT-KEY -> VERIFY-KEY -> CONFIRM-KEY; the receive loop consumes
     // the Trust Center's replies, this only drives the timing
     async fn tc_link_key_exchange<M: Mlme>(
-        &mut self,
+        &self,
         device: &ZigbeeDevice<M>,
         delay: &mut impl DelayNs,
     ) -> Result<(), NetworkError> {
@@ -302,7 +300,7 @@ impl BaseDeviceBehavior {
     }
 
     async fn run_tc_link_key_exchange<M: Mlme>(
-        &mut self,
+        &self,
         device: &ZigbeeDevice<M>,
         delay: &mut impl DelayNs,
     ) -> Result<(), NetworkError> {
@@ -319,7 +317,7 @@ impl BaseDeviceBehavior {
             .await
         else {
             log::warn!("[BDB] TC link key exchange failed: no Node_Desc_rsp");
-            self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
+            self.set_commissioning_status(BdbCommissioningStatus::TclkExFailure);
             return Err(NetworkError::NoTransportKey);
         };
         if node_desc
@@ -361,12 +359,12 @@ impl BaseDeviceBehavior {
                 // already hold, which ends the procedure rather than retrying
                 Some(false) => {
                     log::warn!("[BDB] TC link key exchange failed: unusable TRANSPORT-KEY");
-                    self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
+                    self.set_commissioning_status(BdbCommissioningStatus::TclkExFailure);
                     return Err(NetworkError::NoTransportKey);
                 }
                 None if attempts >= TC_LINK_KEY_EXCHANGE_ATTEMPTS_MAX => {
                     log::warn!("[BDB] TC link key exchange failed: no TRANSPORT-KEY");
-                    self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
+                    self.set_commissioning_status(BdbCommissioningStatus::TclkExFailure);
                     return Err(NetworkError::NoTransportKey);
                 }
                 None => continue,
@@ -422,7 +420,7 @@ impl BaseDeviceBehavior {
                 None if attempts < BDBC_MAX_SAME_NETWORK_RETRY_ATTEMPTS => continue,
                 _ => {
                     log::warn!("[BDB] TC link key exchange failed: no CONFIRM-KEY");
-                    self.bdb_commissioning_status = BdbCommissioningStatus::TclkExFailure;
+                    self.set_commissioning_status(BdbCommissioningStatus::TclkExFailure);
                     return Err(NetworkError::NoTransportKey);
                 }
             }
@@ -432,7 +430,7 @@ impl BaseDeviceBehavior {
     // BDB 10.2.5 steps 3-4: read the trust center's node descriptor, retrying
     // until bdbTCLinkKeyExchangeAttemptsMax attempts are spent
     async fn request_trust_center_node_desc<M: Mlme>(
-        &mut self,
+        &self,
         device: &ZigbeeDevice<M>,
         delay: &mut impl DelayNs,
         tc_short: ShortAddress,
@@ -476,6 +474,8 @@ pub enum BdbError {
 #[cfg(test)]
 mod tests {
     use core::future::Future;
+    use core::sync::atomic::AtomicBool;
+    use core::sync::atomic::Ordering;
 
     use zigbee::nwk::nib;
     use zigbee_mac::Address;
@@ -515,7 +515,7 @@ mod tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
-            async fn set_short_address(&self, address: ShortAddress);
+            async fn configure(&self, config: MacConfig);
             async fn scan_network(
                 &self,
                 ty: ScanType,
@@ -574,23 +574,23 @@ mod tests {
         zigbee::aps::aib::init();
 
         let device = make_device(LogicalType::EndDevice);
-        let mut bdb = BaseDeviceBehavior::new(Config {
+        let bdb = BaseDeviceBehavior::new(Config {
             device_type: LogicalType::EndDevice,
             ..Config::default()
         });
         let result = block_on(bdb.start_initialization_procedure(&device, &mut NoopDelay));
         assert!(matches!(result, Ok(None)));
-        assert!(!bdb.bdb_node_is_on_a_network);
+        assert!(!bdb.node_is_on_a_network());
 
         nib::get_ref().update_network_address(|value| *value = 0x1234);
         let router_device = make_device(LogicalType::Router);
-        let mut router_bdb = BaseDeviceBehavior::new(Config {
+        let router_bdb = BaseDeviceBehavior::new(Config {
             device_type: LogicalType::Router,
             ..Config::default()
         });
         let result =
             block_on(router_bdb.start_initialization_procedure(&router_device, &mut NoopDelay));
         assert!(matches!(result, Ok(None)));
-        assert!(router_bdb.bdb_node_is_on_a_network);
+        assert!(router_bdb.node_is_on_a_network());
     }
 }

--- a/zigbee-mac/src/esp/mod.rs
+++ b/zigbee-mac/src/esp/mod.rs
@@ -25,6 +25,7 @@ use crate::mlme::A_MAX_FRAME_RETRIES;
 use crate::mlme::A_RESPONSE_WAIT_TIME;
 use crate::mlme::AssociationResponse;
 use crate::mlme::MAX_IEEE802154_CHANNELS;
+use crate::mlme::MacConfig;
 use crate::mlme::MacError;
 use crate::mlme::Mlme;
 use crate::mlme::PanDescriptor;
@@ -553,11 +554,13 @@ impl EspMlmeInner<'_> {
         let timeout_us = (A_RESPONSE_WAIT_TIME as u64) * 16;
 
         // retry the poll handshake (7.5.6.3)
+        let mut acked = false;
         for _ in 0..POLL_DATA_RETRIES {
             let (data_req, len) = self.data_request_frame(coord_address)?;
             match self.transmit_acked(&data_req[..len]).await {
                 // no ack after retries: the parent may be busy; keep listening
-                Ok(()) | Err(MacError::NoAck) => {}
+                Ok(()) => acked = true,
+                Err(MacError::NoAck) => {}
                 Err(e) => return Err(e),
             }
             // arm RX for the indirect response (~2-3ms after the poll ack);
@@ -568,7 +571,14 @@ impl EspMlmeInner<'_> {
                 return Ok((len, lqi));
             }
         }
-        Err(MacError::NoData)
+        // an unacknowledged poll says nothing about buffered data: the parent
+        // itself is unreachable, which the NWK layer treats as a missed
+        // keepalive (3.6.10.3)
+        if acked {
+            Err(MacError::NoData)
+        } else {
+            Err(MacError::NoAck)
+        }
     }
 
     async fn transmit_data(&mut self, dest: Address, payload: &[u8]) -> Result<(), MacError> {
@@ -636,15 +646,31 @@ impl Mlme for EspMlme<'_> {
         zigbee_types::IeeeAddress(self.ieee_address)
     }
 
-    async fn set_short_address(&self, address: zigbee_types::ShortAddress) {
-        self.inner
-            .lock()
-            .await
-            .driver
-            .update_driver_config(|config| {
-                config.promiscuous = false;
-                config.short_addr = Some(address.0);
-            });
+    async fn configure(&self, config: MacConfig) {
+        let mut inner = self.inner.lock().await;
+        inner.driver.update_driver_config(|driver| {
+            if let Some(channel) = config.channel {
+                driver.channel = channel;
+            }
+            if let Some(pan_id) = config.pan_id {
+                driver.pan_id = Some(pan_id.0);
+            }
+            if let Some(short_address) = config.short_address {
+                driver.short_addr = Some(short_address.0);
+            }
+            if let Some(promiscuous) = config.promiscuous {
+                driver.promiscuous = promiscuous;
+            }
+            if let Some(auto_ack_rx) = config.auto_ack_rx {
+                driver.auto_ack_rx = auto_ack_rx;
+            }
+            if let Some(auto_ack_tx) = config.auto_ack_tx {
+                driver.auto_ack_tx = auto_ack_tx;
+            }
+        });
+        // arm RX for the new configuration: otherwise reception stays off
+        // until the next transmit triggers rx-on-when-idle
+        inner.driver.start_receive();
     }
 
     async fn scan_network(

--- a/zigbee-mac/src/mlme.rs
+++ b/zigbee-mac/src/mlme.rs
@@ -1,4 +1,5 @@
 use ieee802154::mac::Address;
+use ieee802154::mac::PanId;
 use ieee802154::mac::beacon::SuperframeSpecification;
 use ieee802154::mac::command::AssociationStatus;
 use ieee802154::mac::command::CapabilityInformation;
@@ -36,13 +37,17 @@ pub trait Mlme {
     /// e.g. read from efuse.
     fn ieee_address(&self) -> IeeeAddress;
 
-    /// MLME-SET.request of `macShortAddress` (IEEE 802.15.4 7.4.2).
+    /// MLME-SET.request of the addressing attributes (IEEE 802.15.4 7.4.2)
+    /// and the operating channel.
     ///
-    /// Applies the address the network layer was assigned, so the hardware
-    /// filter accepts unicasts sent to it. [`Self::associate`] already does
-    /// this for the address it obtained; the NWK layer calls this when an
-    /// address is assigned by other means, e.g. a rejoin response.
-    async fn set_short_address(&self, address: ShortAddress);
+    /// Applies what the network layer knows about this device, so the
+    /// hardware filter accepts frames addressed to it: the channel it
+    /// operates on, `macPANId`, and the `macShortAddress` it was assigned.
+    /// [`Self::associate`] already does this for an association; the NWK layer
+    /// calls this when the values come from elsewhere — a rejoin response, a
+    /// parent on another channel, or a restored information base after a
+    /// reset (3.6.8).
+    async fn configure(&self, config: MacConfig);
 
     async fn scan_network(
         &self,
@@ -64,9 +69,11 @@ pub trait Mlme {
     /// receive mode to capture both the ACK (with frame-pending check)
     /// and the subsequent data frame in a single uninterrupted session.
     ///
-    /// Returns `Ok((bytes_written, lqi))` on success, or
+    /// Returns `Ok((bytes_written, lqi))` on success,
     /// `Err(MacError::NoData)` if the ACK has frame-pending clear or
-    /// no data frame arrives within the timeout.
+    /// no data frame arrives within the timeout, and `Err(MacError::NoAck)`
+    /// if the data request itself went unacknowledged — the coordinator is
+    /// unreachable rather than merely idle.
     async fn poll_data(
         &self,
         coord_address: Address,
@@ -89,6 +96,60 @@ pub trait Mlme {
     /// sequence number, addressing) and appends `payload` as the MAC
     /// service data unit.
     async fn transmit_data(&self, dest: Address, payload: &[u8]) -> Result<(), MacError>;
+}
+
+/// MAC attributes the network layer programs (see [`Mlme::configure`]).
+///
+/// Every field is optional: `None` leaves that attribute as the implementation
+/// has it, so a caller only states what it actually knows.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct MacConfig {
+    /// `phyCurrentChannel`: the channel the network operates on.
+    pub channel: Option<u8>,
+    /// `macPANId` of that network.
+    pub pan_id: Option<PanId>,
+    /// `macShortAddress` assigned to this device.
+    pub short_address: Option<ShortAddress>,
+    /// `macPromiscuousMode` (7.4.2): pass every frame up instead of filtering
+    /// on the addresses above.
+    pub promiscuous: Option<bool>,
+    /// Acknowledge received frames that request it (7.5.6.4).
+    pub auto_ack_rx: Option<bool>,
+    /// Wait for the acknowledgement of transmitted frames that request it.
+    pub auto_ack_tx: Option<bool>,
+}
+
+impl MacConfig {
+    /// Attributes of a device operating as a member of a network: filtering on
+    /// its addresses, acknowledging and expecting acknowledgements.
+    pub fn joined(channel: u8, pan_id: PanId, short_address: ShortAddress) -> Self {
+        Self {
+            channel: Some(channel),
+            pan_id: Some(pan_id),
+            short_address: Some(short_address),
+            promiscuous: Some(false),
+            auto_ack_rx: Some(true),
+            auto_ack_tx: Some(true),
+        }
+    }
+}
+
+impl MacConfig {
+    /// Tune the radio to a channel, leaving the addressing attributes alone.
+    pub fn channel(channel: u8) -> Self {
+        Self {
+            channel: Some(channel),
+            ..Self::default()
+        }
+    }
+
+    /// Apply an assigned short address, leaving channel and PAN id alone.
+    pub fn short_address(address: ShortAddress) -> Self {
+        Self {
+            short_address: Some(address),
+            ..Self::default()
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/zigbee-types/src/sync.rs
+++ b/zigbee-types/src/sync.rs
@@ -33,6 +33,23 @@ pub async fn with_timeout<F: Future>(
     .await
 }
 
+/// Hand control back to the executor once, so another task can make progress.
+///
+/// Used by yielding `try_lock` loops: a waiter releases the CPU instead of
+/// spinning while the holder finishes.
+pub async fn yield_now() {
+    let mut yielded = false;
+    poll_fn(|cx| {
+        if yielded {
+            return Poll::Ready(());
+        }
+        yielded = true;
+        cx.waker().wake_by_ref();
+        Poll::Pending
+    })
+    .await;
+}
+
 /// One-shot signal carrying a value to a single waiter.
 ///
 /// The value is produced by the receive path and consumed by the procedure

--- a/zigbee/src/aps/apsme/mod.rs
+++ b/zigbee/src/aps/apsme/mod.rs
@@ -1282,6 +1282,7 @@ mod receive_path_tests {
 
     use zigbee_mac::Address;
     use zigbee_mac::mlme::AssociationResponse;
+    use zigbee_mac::mlme::MacConfig;
     use zigbee_mac::mlme::MacError;
     use zigbee_mac::mlme::Mlme;
     use zigbee_mac::mlme::ScanResult;
@@ -1311,7 +1312,7 @@ mod receive_path_tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
-            async fn set_short_address(&self, address: ShortAddress);
+            async fn configure(&self, config: MacConfig);
             async fn scan_network(
                 &self,
                 ty: ScanType,

--- a/zigbee/src/nwk/nlme/management.rs
+++ b/zigbee/src/nwk/nlme/management.rs
@@ -10,6 +10,7 @@ use zigbee_mac::mlme::PanDescriptor;
 use zigbee_types::IeeeAddress;
 use zigbee_types::ShortAddress;
 
+use crate::nwk::frame::command::network_status::NetworkStatusCode;
 use crate::nwk::nib::CapabilityInformation;
 
 /// 3.2.2.4 - NLME-NETWORK-DISCOVERY.confirm
@@ -118,6 +119,13 @@ pub struct NlmeJoinRequest {
     /// Capability information bitmap (Table 3-62).
     pub capability_information: CapabilityInformation,
     pub security_enabled: bool,
+    /// Channels scanned for a parent when the remembered one does not answer
+    /// a rejoin (ScanChannels). An empty range restricts a rejoin to the
+    /// remembered parent; an association join ignores it and uses the
+    /// neighbor table filled by network discovery.
+    pub scan_channels: core::ops::Range<u8>,
+    /// Scan duration of that rejoin scan (ScanDuration).
+    pub scan_duration: u8,
 }
 /// 3.2.2.14 - NLME-JOIN.indication
 pub struct NlmeJoinIndication {
@@ -204,6 +212,15 @@ pub enum NlmeLeaveStatus {
     MacError,
     /// The requester is not allowed to remove this device (3.6.1.10.3.1).
     NotAuthorized,
+}
+
+/// 3.2.2.32 - NLME-NWK-STATUS.indication (Table 3-37).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct NlmeNwkStatusIndication {
+    /// The error code associated with the failure.
+    pub status: NetworkStatusCode,
+    /// Network address of the device the status information belongs to.
+    pub network_address: ShortAddress,
 }
 
 /// 3.2.2.21 - NLME-RESET.request

--- a/zigbee/src/nwk/nlme/mod.rs
+++ b/zigbee/src/nwk/nlme/mod.rs
@@ -15,6 +15,7 @@
 
 use core::slice;
 use core::sync::atomic::AtomicU8;
+use core::sync::atomic::AtomicU32;
 use core::sync::atomic::Ordering;
 
 use byte::BytesExt;
@@ -31,6 +32,7 @@ use management::NlmeLeaveStatus;
 use management::NlmeNetworkDiscoveryConfirm;
 use management::NlmeNetworkFormationConfirm;
 use management::NlmeNetworkFormationRequest;
+use management::NlmeNwkStatusIndication;
 use management::NlmePermitJoiningConfirm;
 use management::NlmePermitJoiningRequest;
 use management::NlmeStartRouterConfirm;
@@ -41,6 +43,7 @@ use zigbee_mac::Address;
 use zigbee_mac::AssociationStatus;
 use zigbee_mac::MacShortAddress;
 use zigbee_mac::PanId;
+use zigbee_mac::mlme::MacConfig;
 use zigbee_mac::mlme::MacError;
 use zigbee_mac::mlme::Mlme;
 use zigbee_mac::mlme::ScanType;
@@ -59,6 +62,7 @@ use crate::nwk::frame::command::end_device_timeout_request::EndDeviceTimeoutRequ
 use crate::nwk::frame::command::end_device_timeout_response::EndDeviceTimeoutResponse;
 use crate::nwk::frame::command::leave::CommandOptions as LeaveCommandOptions;
 use crate::nwk::frame::command::leave::Leave;
+use crate::nwk::frame::command::network_status::NetworkStatusCode;
 use crate::nwk::frame::command::rejoin_request;
 use crate::nwk::frame::command::rejoin_request::RejoinRequest;
 use crate::nwk::frame::command::rejoin_response::RejoinResponse;
@@ -90,6 +94,18 @@ const NO_PENDING_TIMEOUT: u8 = 0xff;
 // Response (3.4.7.1: indirect transmission for a sleepy child)
 const REJOIN_RESPONSE_POLL_RETRIES: u8 = 20;
 
+// poll attempts covering macResponseWaitTime while waiting for the keepalive's
+// End Device Timeout Response (3.6.10.3)
+const TIMEOUT_RESPONSE_POLL_RETRIES: u8 = 3;
+
+// `parent_timeout_remaining_ms` value meaning "not tracking": either no
+// timeout was negotiated or it already expired
+const PARENT_TIMEOUT_INACTIVE: u32 = 0;
+
+// consecutive transmit failures classifying the link to the parent as failed
+// (3.6.3.7 leaves the counting scheme to the implementer)
+const MAX_PARENT_TRANSMIT_FAILURES: u8 = 3;
+
 #[derive(Debug, Error)]
 pub enum NetworkError {
     #[error("mac error: {0}")]
@@ -106,6 +122,8 @@ pub enum NetworkError {
     FrameTooLong,
     #[error("no APS acknowledgement received")]
     AckTimeout,
+    #[error("parent link failure")]
+    ParentLinkFailure,
     #[error("security error: {0}")]
     SecurityError(#[from] crate::security::SecurityError),
 }
@@ -126,12 +144,37 @@ pub struct Nlme<M> {
     nwk_seq: AtomicU8,
     // requested timeout enum awaiting a response (3.6.10.2); 0xff = none
     pending_timeout_request: AtomicU8,
+    // remaining time before the parent is assumed to have aged this device out
+    // (3.6.10.6); the parent's neighbor entry is the only one an end device
+    // tracks, and the counter is volatile, so it lives here rather than in the
+    // flash-backed neighbor table
+    parent_timeout_remaining_ms: AtomicU32,
     // Rejoin Response (3.4.7) handed from the receive path to the rejoin
     // procedure waiting for it
     rejoin_response: Signal<RejoinResponse>,
+    // End Device Timeout Response (3.4.12) handed from the receive path to the
+    // keepalive waiting for it
+    timeout_response: Signal<EndDeviceTimeoutResponse>,
     // NLME-LEAVE.indication (3.2.2.19) raised by the receive path for the
     // higher layer, which decides whether to re-commission or rejoin
     leave_indication: Signal<NlmeLeaveIndication>,
+    // NLME-NWK-STATUS.indication (3.2.2.32) reporting a network failure to the
+    // higher layer
+    nwk_status_indication: Signal<NlmeNwkStatusIndication>,
+}
+
+/// Keepalive method negotiated with the router parent (3.6.10.3).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum KeepaliveMethod {
+    /// The parent tracks a MAC data poll as a keepalive
+    /// (`nwkParentInformation` bit 0).
+    MacDataPoll,
+    /// The parent expects an End Device Timeout Request
+    /// (`nwkParentInformation` bit 1).
+    TimeoutRequest,
+    /// No timeout was negotiated: the parent ages this device out on its own
+    /// terms and no keepalive is sent.
+    None,
 }
 
 impl<M> Nlme<M>
@@ -150,8 +193,11 @@ where
             mac,
             nwk_seq: AtomicU8::new(0),
             pending_timeout_request: AtomicU8::new(NO_PENDING_TIMEOUT),
+            parent_timeout_remaining_ms: AtomicU32::new(PARENT_TIMEOUT_INACTIVE),
             rejoin_response: Signal::new(),
+            timeout_response: Signal::new(),
             leave_indication: Signal::new(),
+            nwk_status_indication: Signal::new(),
         }
     }
 
@@ -167,6 +213,21 @@ where
     /// 3.2.2.19 - wait for the next NLME-LEAVE.indication.
     pub async fn wait_leave_indication(&self) -> NlmeLeaveIndication {
         self.leave_indication.wait().await
+    }
+
+    /// 3.2.2.32 - take a pending NLME-NWK-STATUS.indication, if any.
+    ///
+    /// Reports a network failure to the higher layer; the indication stays
+    /// pending until taken. A status of
+    /// [`NetworkStatusCode::ParentLinkFailure`] means the link to the parent
+    /// is gone and the device should rejoin (3.6.10.10).
+    pub fn take_nwk_status_indication(&self) -> Option<NlmeNwkStatusIndication> {
+        self.nwk_status_indication.try_take()
+    }
+
+    /// 3.2.2.32 - wait for the next NLME-NWK-STATUS.indication.
+    pub async fn wait_nwk_status_indication(&self) -> NlmeNwkStatusIndication {
+        self.nwk_status_indication.wait().await
     }
 
     fn next_nwk_seq(&self) -> u8 {
@@ -305,19 +366,286 @@ where
         Ok(())
     }
 
+    /// Program the MAC from the restored information base and report whether
+    /// this device is resuming on a network (3.6.8).
+    ///
+    /// A device that was reset while joined keeps its addresses in the NIB but
+    /// the radio comes up unconfigured: the PAN id, short address, channel and
+    /// the filtering that goes with membership have to be applied before it
+    /// can poll its parent again. A device that is not on a network only gets
+    /// the channel it will look for one on, leaving the rest to the join.
+    pub async fn resume(&self, channel: u8) -> bool {
+        let nib = self.nib();
+        let network_address = *nib.network_address();
+        let on_a_network = network_address != NWK_UNASSIGNED_ADDRESS;
+
+        let config = if on_a_network {
+            MacConfig::joined(channel, PanId(*nib.panid()), ShortAddress(network_address))
+        } else {
+            MacConfig::channel(channel)
+        };
+        self.mac.configure(config).await;
+
+        on_a_network
+    }
+
+    /// Negotiate the end-device timeout with the parent (3.6.10.2).
+    ///
+    /// Sends the request and waits for the parent's response, which stores the
+    /// negotiated timeout and the parent's keepalive methods in the NIB.
+    /// Returns whether a timeout was negotiated: a legacy parent never answers
+    /// and keeps its own default, leaving this device without a keepalive
+    /// method.
+    pub async fn negotiate_end_device_timeout(&self) -> Result<bool, NetworkError> {
+        // arm before transmitting: the response may be delivered by a
+        // concurrently running receive loop
+        self.timeout_response.reset();
+        self.send_end_device_timeout_request().await?;
+
+        let response = with_timeout(
+            self.timeout_response.wait(),
+            self.poll_until_timeout_response(TIMEOUT_RESPONSE_POLL_RETRIES),
+        )
+        .await
+        .or_else(|| self.timeout_response.try_take());
+
+        match response {
+            Some(response) if response.status == EndDeviceTimeoutResponse::STATUS_SUCCESS => {
+                Ok(true)
+            }
+            Some(response) => {
+                log::warn!(
+                    "[NWK] end-device timeout rejected (status={:#04x})",
+                    response.status
+                );
+                Ok(false)
+            }
+            None => {
+                log::warn!("[NWK] no end-device timeout response, assuming legacy parent");
+                Ok(false)
+            }
+        }
+    }
+
     /// Recommended maximum poll interval in milliseconds, allowing three
     /// keepalives per negotiated timeout period (3.6.10.3).
     ///
     /// Returns `None` when no timeout was negotiated or the parent does not
     /// support the MAC data poll keepalive method.
     pub fn negotiated_poll_interval_ms(&self) -> Option<u32> {
-        let nib = self.nib();
-        let seconds = end_device_timeout_request::timeout_seconds(*nib.end_device_timeout())?;
-        let parent_information = *nib.parent_information();
-        if parent_information & EndDeviceTimeoutResponse::MAC_DATA_POLL_KEEPALIVE == 0 {
+        if self.keepalive_method() != KeepaliveMethod::MacDataPoll {
             return None;
         }
-        Some(seconds * 1000 / 3)
+        self.keepalive_interval_ms()
+    }
+
+    /// Keepalive method the parent expects (3.6.10.3).
+    ///
+    /// Bit 0 of `nwkParentInformation` takes precedence over bit 1; without a
+    /// negotiated timeout no keepalive is sent.
+    pub fn keepalive_method(&self) -> KeepaliveMethod {
+        let nib = self.nib();
+        if end_device_timeout_request::timeout_seconds(*nib.end_device_timeout()).is_none() {
+            return KeepaliveMethod::None;
+        }
+        let parent_information = *nib.parent_information();
+        if parent_information & EndDeviceTimeoutResponse::MAC_DATA_POLL_KEEPALIVE != 0 {
+            KeepaliveMethod::MacDataPoll
+        } else if parent_information & EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE != 0 {
+            KeepaliveMethod::TimeoutRequest
+        } else {
+            KeepaliveMethod::None
+        }
+    }
+
+    /// Recommended interval between keepalives in milliseconds: three
+    /// keepalives per negotiated Device Timeout period (3.6.10.3).
+    ///
+    /// Returns `None` when no timeout was negotiated with the parent.
+    pub fn keepalive_interval_ms(&self) -> Option<u32> {
+        Some(self.negotiated_timeout_ms()? / 3)
+    }
+
+    // negotiated Device Timeout period in milliseconds (Table 3.52)
+    fn negotiated_timeout_ms(&self) -> Option<u32> {
+        let seconds =
+            end_device_timeout_request::timeout_seconds(*self.nib().end_device_timeout())?;
+        Some(seconds.saturating_mul(1000))
+    }
+
+    /// Send one keepalive to the parent (3.6.10.3).
+    ///
+    /// The method follows `nwkParentInformation`: a MAC data poll, or an End
+    /// Device Timeout Request whose response is awaited. A failed timeout
+    /// request raises an NLME-NWK-STATUS.indication with
+    /// [`NetworkStatusCode::ParentLinkFailure`] and returns
+    /// [`NetworkError::ParentLinkFailure`]; a successful keepalive restarts
+    /// the local timeout (3.6.10.6).
+    pub async fn send_keepalive(&self) -> Result<(), NetworkError> {
+        match self.keepalive_method() {
+            KeepaliveMethod::MacDataPoll => self.mac_data_poll_keepalive().await,
+            KeepaliveMethod::TimeoutRequest => self.timeout_request_keepalive().await,
+            KeepaliveMethod::None => Ok(()),
+        }
+    }
+
+    // 3.6.10.3: a data poll refreshes the parent's timeout on its own; any
+    // frame it retrieves belongs to the receive loop, which is not running
+    // when the higher layer drives the keepalive itself
+    async fn mac_data_poll_keepalive(&self) -> Result<(), NetworkError> {
+        let mut buf = [0u8; 256];
+        match self.poll_nwk_frame(&mut buf).await {
+            Ok(Some(_)) => log::debug!("[NWK] keepalive poll dropped a data frame"),
+            Ok(None) => (),
+            Err(e) => return Err(e),
+        }
+        self.refresh_parent_timeout();
+        Ok(())
+    }
+
+    // 3.6.10.3: unicast an End Device Timeout Request and wait
+    // macResponseWaitTime for the response; anything else is a parent link
+    // failure
+    async fn timeout_request_keepalive(&self) -> Result<(), NetworkError> {
+        // arm before transmitting: the response may be delivered by a
+        // concurrently running receive loop
+        self.timeout_response.reset();
+        if let Err(e) = self.send_end_device_timeout_request().await {
+            log::warn!("[NWK] keepalive transmission failed ({e:?})");
+            return Err(self.parent_link_failure());
+        }
+
+        let response = with_timeout(
+            self.timeout_response.wait(),
+            self.poll_until_timeout_response(TIMEOUT_RESPONSE_POLL_RETRIES),
+        )
+        .await
+        // the response may have arrived in the very poll that ended the polling
+        .or_else(|| self.timeout_response.try_take());
+
+        match response {
+            Some(response) if response.status == EndDeviceTimeoutResponse::STATUS_SUCCESS => {
+                self.refresh_parent_timeout();
+                Ok(())
+            }
+            Some(response) => {
+                log::warn!("[NWK] keepalive rejected (status={:#04x})", response.status);
+                Err(self.parent_link_failure())
+            }
+            None => {
+                log::warn!("[NWK] no keepalive response from parent");
+                Err(self.parent_link_failure())
+            }
+        }
+    }
+
+    // poll the parent until the End Device Timeout Response has been processed
+    // or `retries` polls went unanswered; a sleepy child only receives the
+    // response by polling for it
+    async fn poll_until_timeout_response(&self, retries: u8) {
+        let mut buf = [0u8; 128];
+        for _ in 0..retries {
+            if self.timeout_response.is_signaled() {
+                return;
+            }
+            match self.poll_parent(&mut buf).await {
+                Ok(Some(len)) => match self.process_received_nwk_frame(&mut buf[..len]).await {
+                    Ok(Some(_)) => log::debug!("[NWK] keepalive poll dropped a data frame"),
+                    Ok(None) => (),
+                    Err(e) => log::debug!("[NWK] keepalive frame not processed: {e:?}"),
+                },
+                Ok(None) => (),
+                Err(e) => log::debug!("[NWK] keepalive poll failed: {e:?}"),
+            }
+        }
+    }
+
+    /// Restart the local end-device timeout after evidence that the parent
+    /// still holds this device in its neighbor table (3.6.10.6).
+    pub fn refresh_parent_timeout(&self) {
+        let remaining = self
+            .negotiated_timeout_ms()
+            .unwrap_or(PARENT_TIMEOUT_INACTIVE);
+        self.parent_timeout_remaining_ms
+            .store(remaining, Ordering::Relaxed);
+    }
+
+    /// Advance the local end-device timeout by `elapsed_ms` (3.6.10.6).
+    ///
+    /// Returns `true` once the timeout expires: the parent is assumed to have
+    /// aged this device out, which is reported to the higher layer as an
+    /// NLME-NWK-STATUS.indication with
+    /// [`NetworkStatusCode::ParentLinkFailure`]. Tracking then stops until the
+    /// next successful keepalive.
+    pub fn tick_parent_timeout(&self, elapsed_ms: u32) -> bool {
+        let remaining = self.parent_timeout_remaining_ms.load(Ordering::Relaxed);
+        if remaining == PARENT_TIMEOUT_INACTIVE {
+            return false;
+        }
+        let remaining = remaining.saturating_sub(elapsed_ms.max(1));
+        self.parent_timeout_remaining_ms
+            .store(remaining, Ordering::Relaxed);
+        if remaining != PARENT_TIMEOUT_INACTIVE {
+            return false;
+        }
+        log::warn!("[NWK] end-device timeout elapsed, assuming aged out by parent");
+        self.parent_link_failure();
+        true
+    }
+
+    /// Transmit a built frame through the parent, tracking the link
+    /// (3.6.3.7).
+    ///
+    /// Every neighbor with an outgoing link carries a failure counter; once
+    /// the link to the parent counts as failed, the higher layer is informed
+    /// with an NLME-NWK-STATUS.indication of `ParentLinkFailure` (3.6.3.7.1)
+    /// and [`NetworkError::ParentLinkFailure`] is returned.
+    async fn transmit_via_parent(&self, buf: &[u8]) -> Result<(), NetworkError> {
+        let parent = self.parent_address()?;
+        let Err(e) = self.mac.transmit_data(parent, buf).await else {
+            // an acknowledged frame proves the parent still holds this device
+            // in its neighbor table (3.6.10.6)
+            self.update_parent_neighbor(|neighbor| neighbor.transmit_failure = 0);
+            self.refresh_parent_timeout();
+            return Ok(());
+        };
+
+        let mut failures = 0;
+        self.update_parent_neighbor(|neighbor| {
+            neighbor.transmit_failure = neighbor.transmit_failure.saturating_add(1);
+            failures = neighbor.transmit_failure;
+        });
+        log::debug!("[NWK] transmission via parent failed ({e:?}), failures={failures}");
+        if failures < MAX_PARENT_TRANSMIT_FAILURES {
+            return Err(e.into());
+        }
+
+        self.update_parent_neighbor(|neighbor| neighbor.transmit_failure = 0);
+        Err(self.parent_link_failure())
+    }
+
+    // apply `update` to the parent's neighbor table entry, if there is one
+    fn update_parent_neighbor(&self, update: impl FnOnce(&mut NwkNeighbor)) {
+        self.nib().update_neighbor_table(|table| {
+            if let Some(parent) = table
+                .iter_mut()
+                .find(|n| n.relationship == relationship::PARENT)
+            {
+                update(parent);
+            }
+        });
+    }
+
+    // raise NLME-NWK-STATUS.indication 0x09 (3.6.3.7.1, 3.6.10.3, 3.2.2.32)
+    fn parent_link_failure(&self) -> NetworkError {
+        let network_address = self
+            .parent_short_address()
+            .unwrap_or(ShortAddress(NWK_UNASSIGNED_ADDRESS));
+        self.nwk_status_indication.signal(NlmeNwkStatusIndication {
+            status: NetworkStatusCode::ParentLinkFailure,
+            network_address,
+        });
+        NetworkError::ParentLinkFailure
     }
 
     /// Returns a reference to the global NIB singleton.
@@ -325,21 +653,43 @@ where
         nib::get_ref()
     }
 
-    /// Select parent candidates from the neighbor table (3.6.1.4.1.1).
+    /// Select parent candidates for an association join (3.6.1.4.1.1).
     fn select_parent_candidates(
         &self,
         extended_pan_id: IeeeAddress,
         join_as_router: bool,
     ) -> heapless::Vec<usize, 16> {
+        self.select_candidates(extended_pan_id, join_as_router, true)
+    }
+
+    /// Select parent candidates for a rejoin (3.6.1.4.2).
+    ///
+    /// Same selection as for a join except that the network need not permit
+    /// joining: a rejoin reconnects a device the network already knows.
+    fn select_rejoin_candidates(
+        &self,
+        extended_pan_id: IeeeAddress,
+        join_as_router: bool,
+    ) -> heapless::Vec<usize, 16> {
+        self.select_candidates(extended_pan_id, join_as_router, false)
+    }
+
+    fn select_candidates(
+        &self,
+        extended_pan_id: IeeeAddress,
+        join_as_router: bool,
+        require_permit_joining: bool,
+    ) -> heapless::Vec<usize, 16> {
         let table = self.nib().neighbor_table();
         log::debug!("[NWK-JOIN] neighbor table: {table:#?}");
         let stack_profile = self.nib().stack_profile();
+        let permits = |n: &NwkNeighbor| !require_permit_joining || n.permit_joining;
 
         // 3.6.1.4.1.1: the update id wraps back to zero, so it is treated as
         // a modular counter - an id `b` is newer than `a` when the signed
         // difference `(b - a) as i8` is positive
         let mut matching = table.iter().filter(|n| {
-            n.extended_pan_id == extended_pan_id && n.permit_joining && n.potential_parent == 1
+            n.extended_pan_id == extended_pan_id && permits(n) && n.potential_parent == 1
         });
 
         let Some(first) = matching.next() else {
@@ -365,7 +715,7 @@ where
                 // enough link cost, a potential parent, and on the most
                 // recent update id
                 n.extended_pan_id == extended_pan_id
-                    && n.permit_joining
+                    && permits(n)
                     && if join_as_router {
                         n.router_capacity
                     } else {
@@ -409,6 +759,8 @@ where
         let nib = self.nib();
         nib.update_parent_information(|value| *value = 0);
         nib.update_end_device_timeout(|value| *value = NO_PENDING_TIMEOUT);
+        self.parent_timeout_remaining_ms
+            .store(PARENT_TIMEOUT_INACTIVE, Ordering::Relaxed);
     }
 
     /// Find the parent's MAC address from the neighbor table.
@@ -579,8 +931,6 @@ where
             }
             // 3.6.10.2: on success store the parent information bitmask and
             // the negotiated timeout, otherwise the parent keeps its default
-            // TODO: timeout-request keepalive method (bit 1) and parent link
-            // failure (NWK status 0x09) on keepalive failure
             Command::EndDeviceTimeoutResponse(response) => {
                 let pending = self
                     .pending_timeout_request
@@ -591,6 +941,9 @@ where
                     let nib = self.nib();
                     nib.update_parent_information(|value| *value = response.parent_information);
                     nib.update_end_device_timeout(|value| *value = pending);
+                    // the parent restarted its timeout counter for this device
+                    // (3.6.10.5), so the local one follows (3.6.10.6)
+                    self.refresh_parent_timeout();
                     log::info!(
                         "[NWK] end-device timeout negotiated: enum={pending}, parent_information={:#04x}",
                         response.parent_information
@@ -601,6 +954,8 @@ where
                         response.status
                     );
                 }
+                // hand it to a keepalive waiting for it (3.6.10.3)
+                self.timeout_response.signal(response);
             }
             Command::Reserved(id) => log::trace!("[NWK] reserved command {id:#04x} (ignored)"),
         }
@@ -662,6 +1017,14 @@ where
         {
             log::warn!("[NWK] failed to announce leave: {e:?}");
         }
+
+        // 3.2.2.19: removed by another device, so the indication carries a NULL
+        // device address; with the rejoin flag it asks the higher layer to come
+        // back onto the network (3.6.1.10.4)
+        self.leave_indication.signal(NlmeLeaveIndication {
+            device_address: None,
+            rejoin: options.rejoin(),
+        });
     }
 
     /// Validate a leave request against 3.6.1.10.3.1, which governs both the
@@ -1076,12 +1439,14 @@ where
         fail(last_status)
     }
 
-    /// NLME-JOIN.request with `RejoinNetwork::NwkRejoin` (3.2.2.13.3).
+    /// NLME-JOIN.request with `RejoinNetwork::NwkRejoin` (3.6.1.4.2).
     ///
     /// Reconnects to a network this device remembers — extended PAN id,
-    /// parent, network key — without a fresh MLME-SCAN: it unicasts a Rejoin
-    /// Request (3.4.6) to the previously known parent and waits for the
-    /// Rejoin Response (3.4.7).
+    /// network key — by unicasting a Rejoin Request (3.4.6) and waiting for
+    /// the Rejoin Response (3.4.7). The remembered parent is tried first; if
+    /// it does not answer, `request.scan_channels` are scanned for another
+    /// router of the same network to rejoin through, which may operate on a
+    /// different channel.
     ///
     /// `request.security_enabled` selects the rejoin flavour: `true` secures
     /// the Rejoin Request with the active network key (Secure Rejoin,
@@ -1094,15 +1459,15 @@ where
 
         // a rejoin only makes sense against a network this device already
         // remembers (BDB 7.1 step 4 only reaches here when
-        // bdbNodeIsOnANetwork is TRUE and the extended PAN id is known)
+        // bdbNodeIsOnANetwork is TRUE and the extended PAN id is known). A
+        // leave zeroes nwkExtendedPANId (3.6.1.10.1) without ending the rejoin
+        // path, so an unknown extended PAN id takes the requested one
+        let remembered_epid = *self.nib().extended_panid();
         if *self.nib().network_address() == 0xffff
-            || *self.nib().extended_panid() != request.extended_pan_id.0
+            || (remembered_epid != 0 && remembered_epid != request.extended_pan_id.0)
         {
             return fail(NlmeJoinStatus::InvalidRequest);
         }
-        let Ok(parent) = self.parent_short_address() else {
-            return fail(NlmeJoinStatus::InvalidRequest);
-        };
 
         // whether joining or rejoining, nwkParentInformation is reset
         // (3.2.2.13.3)
@@ -1110,6 +1475,65 @@ where
         self.nib()
             .update_capability_information(|value| *value = request.capability_information);
 
+        // the remembered parent needs no scan: try it before the discovery
+        // below rebuilds the neighbor table from fresh beacons
+        let mut last_status = NlmeJoinStatus::InvalidRequest;
+        if let Ok(parent) = self.parent_short_address() {
+            match self.rejoin_via_parent(parent, &request).await {
+                // the channel is whatever the radio is already tuned to
+                Ok(response) => return self.rejoin_confirm(response, &request, 0).await,
+                Err(status) => {
+                    log::debug!("[NWK-REJOIN] remembered parent failed ({status:?})");
+                    last_status = status;
+                }
+            }
+        }
+
+        if request.scan_channels.is_empty() {
+            return fail(last_status);
+        }
+
+        log::debug!(
+            "[NWK-REJOIN] scanning {:?} for another parent",
+            request.scan_channels
+        );
+        if let Err(e) = self
+            .network_discovery(request.scan_channels.clone(), request.scan_duration)
+            .await
+        {
+            log::warn!("[NWK-REJOIN] scan failed: {e:?}");
+            return fail(NlmeJoinStatus::MacError);
+        }
+
+        let join_as_router = request.capability_information.device_type();
+        let candidates = self.select_rejoin_candidates(request.extended_pan_id, join_as_router);
+        if candidates.is_empty() {
+            log::warn!("[NWK-REJOIN] no parent candidate found");
+            return fail(NlmeJoinStatus::NotPermitted);
+        }
+
+        for candidate_idx in candidates {
+            let Some((parent, channel)) = self.adopt_parent(candidate_idx).await else {
+                continue;
+            };
+            match self.rejoin_via_parent(parent, &request).await {
+                Ok(response) => return self.rejoin_confirm(response, &request, channel).await,
+                Err(status) => {
+                    log::debug!("[NWK-REJOIN] candidate {parent:?} failed ({status:?})");
+                    last_status = status;
+                }
+            }
+        }
+
+        fail(last_status)
+    }
+
+    /// One Rejoin Request/Response exchange with `parent` (3.4.6, 3.4.7).
+    async fn rejoin_via_parent(
+        &self,
+        parent: ShortAddress,
+        request: &NlmeJoinRequest,
+    ) -> Result<RejoinResponse, NlmeJoinStatus> {
         let command = Command::RejoinRequest(RejoinRequest {
             // the Capability Information bit layout (Table 3-62) is shared
             // with `nwk::nib::CapabilityInformation`
@@ -1119,59 +1543,96 @@ where
         });
 
         let mut buf = [0u8; 128];
-        let Ok(len) =
-            self.build_nwk_command_frame(parent, command, request.security_enabled, &mut buf)
-        else {
-            return fail(NlmeJoinStatus::MacError);
-        };
-        let Ok(parent_addr) = self.parent_address() else {
-            return fail(NlmeJoinStatus::InvalidRequest);
-        };
+        let len = self
+            .build_nwk_command_frame(parent, command, request.security_enabled, &mut buf)
+            .map_err(|_| NlmeJoinStatus::MacError)?;
+        let parent_addr = self
+            .parent_address()
+            .map_err(|_| NlmeJoinStatus::InvalidRequest)?;
 
         // arm before transmitting: the response is delivered by the receive
         // path, which may be this procedure's own poll or a concurrent loop
         self.rejoin_response.reset();
-        if self
-            .mac
+        self.mac
             .transmit_data(parent_addr, &buf[..len])
             .await
-            .is_err()
-        {
-            return fail(NlmeJoinStatus::MacError);
-        }
+            .map_err(|_| NlmeJoinStatus::MacError)?;
 
-        let Some(response) = self
+        let response = self
             .await_rejoin_response(REJOIN_RESPONSE_POLL_RETRIES)
             .await
-        else {
-            return fail(NlmeJoinStatus::MacError);
-        };
+            .ok_or(NlmeJoinStatus::MacError)?;
 
-        if response.status == u8::from(AssociationStatus::NetworkAtCapacity) {
-            return fail(NlmeJoinStatus::PanAtCapacity);
+        match response.status {
+            status if status == u8::from(AssociationStatus::Successful) => Ok(response),
+            status if status == u8::from(AssociationStatus::NetworkAtCapacity) => {
+                Err(NlmeJoinStatus::PanAtCapacity)
+            }
+            status if status == u8::from(AssociationStatus::AccessDenied) => {
+                Err(NlmeJoinStatus::PanAccessDenied)
+            }
+            _ => Err(NlmeJoinStatus::MacError),
         }
-        if response.status == u8::from(AssociationStatus::AccessDenied) {
-            return fail(NlmeJoinStatus::PanAccessDenied);
-        }
-        if response.status != u8::from(AssociationStatus::Successful) {
-            return fail(NlmeJoinStatus::MacError);
-        }
+    }
 
+    /// Build the successful NLME-JOIN.confirm of a rejoin (3.2.2.15).
+    async fn rejoin_confirm(
+        &self,
+        response: RejoinResponse,
+        request: &NlmeJoinRequest,
+        channel: u8,
+    ) -> NlmeJoinConfirm {
         // the receive path stored the assigned address; the hardware filter has
         // to follow it
-        self.mac.set_short_address(response.network_address).await;
+        self.mac
+            .configure(MacConfig::short_address(response.network_address))
+            .await;
+        // 3.2.2.13.3: nwkExtendedPANId names the network we are on again
+        self.nib()
+            .update_extended_panid(|value| *value = request.extended_pan_id.0);
 
         NlmeJoinConfirm {
             status: NlmeJoinStatus::Success,
             network_address: response.network_address,
             extended_pan_id: request.extended_pan_id,
-            // the operating channel isn't tracked in the NIB — the caller is
-            // responsible for having the radio already tuned to it (BDB
-            // 7.1 step 4 passes ScanChannels=0: no scan is performed here)
-            channel: 0,
+            channel,
             enhanced_beacon_type: false,
             mac_interface_index: 0u8,
         }
+    }
+
+    /// Make the neighbor at `candidate_idx` this device's parent and tune the
+    /// radio to its channel, returning its address and channel.
+    ///
+    /// A rejoin may land on a router other than the remembered parent, and the
+    /// network may meanwhile have moved to another channel (3.6.1.4.2).
+    async fn adopt_parent(&self, candidate_idx: usize) -> Option<(ShortAddress, u8)> {
+        let nib = self.nib();
+        let (parent, channel, pan_id, update_id) = {
+            let table = nib.neighbor_table();
+            let neighbor = table.get(candidate_idx)?;
+            (
+                neighbor.network_address,
+                neighbor.logical_channel,
+                neighbor.pan_id,
+                neighbor.update_id,
+            )
+        };
+
+        nib.update_neighbor_table(|table| {
+            for (index, neighbor) in table.iter_mut().enumerate() {
+                neighbor.relationship = if index == candidate_idx {
+                    relationship::PARENT
+                } else {
+                    relationship::NONE
+                };
+            }
+        });
+        nib.update_panid(|value| *value = pan_id);
+        nib.update_update_id(|value| *value = update_id);
+        self.mac.configure(MacConfig::channel(channel)).await;
+
+        Some((parent, channel))
     }
 
     /// Wait for the receive path to deliver the Rejoin Response (3.4.7).
@@ -1256,9 +1717,7 @@ where
         let total_len = self.build_nwk_data_frame(destination, secure, payload, &mut buf)?;
         // 3.6.5: a sleepy end device unicasts broadcasts to its parent,
         // which relays them into the network on its behalf
-        let mac_dest = self.parent_address()?;
-        self.mac.transmit_data(mac_dest, &buf[..total_len]).await?;
-        Ok(())
+        self.transmit_via_parent(&buf[..total_len]).await
     }
 
     /// Send an NWK data frame to a specific destination (3.6.3).
@@ -1277,9 +1736,7 @@ where
         let mut buf = [0u8; 256];
         let total_len = self.build_nwk_data_frame(destination, secure, payload, &mut buf)?;
         // end devices route via parent
-        let mac_dest = self.parent_address()?;
-        self.mac.transmit_data(mac_dest, &buf[..total_len]).await?;
-        Ok(())
+        self.transmit_via_parent(&buf[..total_len]).await
     }
 }
 
@@ -1289,6 +1746,7 @@ mod tests {
 
     use zigbee_mac::AssociationStatus;
     use zigbee_mac::mlme::AssociationResponse;
+    use zigbee_mac::mlme::MacConfig;
     use zigbee_mac::mlme::MacError;
     use zigbee_mac::mlme::ScanResult;
     use zigbee_mac::mlme::ScanType;
@@ -1329,7 +1787,7 @@ mod tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
-            async fn set_short_address(&self, address: ShortAddress);
+            async fn configure(&self, config: MacConfig);
             async fn scan_network(
                 &self,
                 ty: ScanType,
@@ -1410,6 +1868,8 @@ mod tests {
             rejoin_network: RejoinNetwork::Association,
             capability_information: CapabilityInformation(0x80),
             security_enabled: false,
+            scan_channels: 0..0,
+            scan_duration: 0,
         }
     }
 
@@ -1761,6 +2221,9 @@ mod tests {
             rejoin_network: RejoinNetwork::NwkRejoin,
             capability_information: CapabilityInformation(0x80),
             security_enabled: true,
+            // no scan: these exercise the remembered-parent path
+            scan_channels: 0..0,
+            scan_duration: 0,
         }
     }
 
@@ -1868,9 +2331,9 @@ mod tests {
             Ok((response.len(), 200u8))
         });
         // the assigned address has to reach the hardware filter
-        mac.expect_set_short_address()
+        mac.expect_configure()
             .times(1)
-            .withf(|address| *address == ShortAddress(0x5678))
+            .withf(|config| config.short_address == Some(ShortAddress(0x5678)))
             .returning(|_| ());
 
         let (_guard, nlme) = make_nlme(mac);
@@ -2364,5 +2827,338 @@ mod tests {
             *value = EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE;
         });
         assert_eq!(nlme.negotiated_poll_interval_ms(), None);
+    }
+
+    #[test]
+    fn keepalive_method_follows_parent_information() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        let nib = nlme.nib();
+
+        // no negotiated timeout
+        assert_eq!(nlme.keepalive_method(), KeepaliveMethod::None);
+
+        nib.update_end_device_timeout(|value| *value = 1);
+        nib.update_parent_information(|value| {
+            *value = EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE;
+        });
+        assert_eq!(nlme.keepalive_method(), KeepaliveMethod::TimeoutRequest);
+
+        // bit 0 takes precedence over bit 1
+        nib.update_parent_information(|value| {
+            *value = EndDeviceTimeoutResponse::MAC_DATA_POLL_KEEPALIVE
+                | EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE;
+        });
+        assert_eq!(nlme.keepalive_method(), KeepaliveMethod::MacDataPoll);
+    }
+
+    #[test]
+    fn local_timeout_expiry_raises_parent_link_failure() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        seed_joined_nib(&nlme);
+        let nib = nlme.nib();
+
+        // no negotiated timeout: nothing to track
+        assert!(!nlme.tick_parent_timeout(10_000));
+        assert!(nlme.take_nwk_status_indication().is_none());
+
+        // 10 s timeout, refreshed by the negotiation
+        nib.update_end_device_timeout(|value| *value = 0);
+        nib.update_parent_information(|value| {
+            *value = EndDeviceTimeoutResponse::MAC_DATA_POLL_KEEPALIVE;
+        });
+        nlme.refresh_parent_timeout();
+
+        assert!(!nlme.tick_parent_timeout(4_000));
+        assert!(!nlme.tick_parent_timeout(4_000));
+        assert!(nlme.tick_parent_timeout(4_000));
+
+        let indication = nlme
+            .take_nwk_status_indication()
+            .expect("indication raised");
+        assert_eq!(indication.status, NetworkStatusCode::ParentLinkFailure);
+        assert_eq!(indication.network_address, ShortAddress(0x0000));
+
+        // expiry stops the tracking: it fires once, until the next keepalive
+        assert!(!nlme.tick_parent_timeout(4_000));
+        assert!(nlme.take_nwk_status_indication().is_none());
+    }
+
+    #[test]
+    fn keepalive_without_response_raises_parent_link_failure() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+        mac.expect_poll_data()
+            .returning(|_, _| Err(MacError::NoData));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+        let nib = nlme.nib();
+        nib.update_end_device_timeout(|value| *value = 1);
+        nib.update_parent_information(|value| {
+            *value = EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE;
+        });
+
+        let result = block_on(nlme.send_keepalive());
+        assert!(matches!(result, Err(NetworkError::ParentLinkFailure)));
+        assert_eq!(
+            nlme.take_nwk_status_indication().map(|i| i.status),
+            Some(NetworkStatusCode::ParentLinkFailure)
+        );
+    }
+
+    #[test]
+    fn keepalive_response_refreshes_local_timeout() {
+        // the parent answers the keepalive on the next poll
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+        mac.expect_poll_data().returning(|_, buf| {
+            let frame = encrypted_timeout_response(EndDeviceTimeoutResponse::STATUS_SUCCESS);
+            buf[..frame.len()].copy_from_slice(&frame);
+            Ok((frame.len(), 200))
+        });
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+        let nib = nlme.nib();
+        // request and negotiate the 120 s timeout enumeration
+        nib.update_end_device_timeout_default(|value| *value = 1);
+        nib.update_end_device_timeout(|value| *value = 1);
+        nib.update_parent_information(|value| {
+            *value = EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE;
+        });
+
+        assert!(block_on(nlme.send_keepalive()).is_ok());
+        assert!(nlme.take_nwk_status_indication().is_none());
+        // the negotiated 120 s are being tracked again
+        assert!(!nlme.tick_parent_timeout(119_000));
+        assert!(nlme.tick_parent_timeout(1_000));
+    }
+
+    #[test]
+    fn repeated_transmit_failures_report_parent_link_failure() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .returning(|_, _| Err(MacError::NoAck));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        // 3.6.3.7: a single failure does not condemn the link
+        for _ in 1..MAX_PARENT_TRANSMIT_FAILURES {
+            assert!(matches!(
+                block_on(nlme.send_data(ShortAddress(0x0000), true, &[1, 2, 3])),
+                Err(NetworkError::MacError(_))
+            ));
+            assert!(nlme.take_nwk_status_indication().is_none());
+        }
+
+        // 3.6.3.7.1: the failed link to the parent is reported as 0x09
+        assert!(matches!(
+            block_on(nlme.send_data(ShortAddress(0x0000), true, &[1, 2, 3])),
+            Err(NetworkError::ParentLinkFailure)
+        ));
+        assert_eq!(
+            nlme.take_nwk_status_indication().map(|i| i.status),
+            Some(NetworkStatusCode::ParentLinkFailure)
+        );
+        // the counter restarts, so the next failure is not reported at once
+        assert!(matches!(
+            block_on(nlme.send_data(ShortAddress(0x0000), true, &[1, 2, 3])),
+            Err(NetworkError::MacError(_))
+        ));
+    }
+
+    #[test]
+    fn successful_transmission_clears_the_failure_counter() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .returning(|_, _| Err(MacError::NoAck));
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let _ = block_on(nlme.send_data(ShortAddress(0x0000), true, &[1, 2, 3]));
+        assert!(block_on(nlme.send_data(ShortAddress(0x0000), true, &[1, 2, 3])).is_ok());
+
+        let table = nlme.nib().neighbor_table();
+        let parent = table
+            .iter()
+            .find(|n| n.relationship == relationship::PARENT)
+            .expect("parent");
+        assert_eq!(parent.transmit_failure, 0);
+    }
+
+    #[test]
+    fn select_rejoin_candidates_ignores_permit_joining() {
+        let (_guard, nlme) = make_nlme(MockMlme::new());
+        let mut closed = make_neighbor(0xAAAA, 0x1234, 0xDEAD, 200, 1);
+        closed.permit_joining = false;
+        nlme.nib().update_neighbor_table(|table| {
+            let _ = table.push(closed);
+        });
+
+        // a closed network still accepts a device it already knows (3.6.1.4.2)
+        assert!(
+            nlme.select_parent_candidates(IeeeAddress(0xDEAD), false)
+                .is_empty()
+        );
+        assert_eq!(
+            nlme.select_rejoin_candidates(IeeeAddress(0xDEAD), false),
+            heapless::Vec::<usize, 16>::from_slice(&[0]).unwrap()
+        );
+    }
+
+    #[test]
+    fn rejoin_scans_when_the_known_parent_is_gone() {
+        let mut mac = MockMlme::new();
+        // the remembered parent no longer answers, so a scan follows
+        mac.expect_transmit_data()
+            .times(1)
+            .returning(|_, _| Err(MacError::NoAck));
+        mac.expect_scan_network().times(1).returning(|_, _, _| {
+            Ok(ScanResult {
+                scan_type: ScanType::Active,
+                pan_descriptor: Default::default(),
+            })
+        });
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let mut request = rejoin_request(0xDEAD);
+        request.scan_channels = 20..21;
+        let confirm = block_on(nlme.join(request));
+
+        // the scan found no beacon of the remembered network
+        assert_eq!(confirm.status, NlmeJoinStatus::NotPermitted);
+    }
+
+    #[test]
+    fn adopt_parent_follows_the_candidate_channel() {
+        let mut mac = MockMlme::new();
+        mac.expect_configure()
+            .times(1)
+            .withf(|config| config.channel == Some(20))
+            .returning(|_| ());
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+        let mut candidate = make_neighbor(0xAAAA, 0x1234, 0xDEAD, 200, 1);
+        candidate.logical_channel = 20;
+        candidate.update_id = 7;
+        nlme.nib().update_neighbor_table(|table| {
+            let _ = table.push(candidate);
+        });
+
+        let adopted = block_on(nlme.adopt_parent(1));
+
+        assert_eq!(adopted, Some((ShortAddress(0x1234), 20)));
+        assert_eq!(nlme.parent_short_address().unwrap(), ShortAddress(0x1234));
+        assert_eq!(*nlme.nib().update_id(), 7);
+        // the previous parent is demoted: only one entry is the parent
+        let table = nlme.nib().neighbor_table();
+        assert_eq!(
+            table
+                .iter()
+                .filter(|n| n.relationship == relationship::PARENT)
+                .count(),
+            1
+        );
+    }
+
+    #[test]
+    fn rejoin_without_scan_channels_keeps_the_remembered_parent_failure() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data()
+            .times(1)
+            .returning(|_, _| Err(MacError::NoAck));
+        // no scan_network expectation: a call here would panic the mock
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+        assert_eq!(confirm.status, NlmeJoinStatus::MacError);
+    }
+
+    #[test]
+    fn leave_request_from_parent_raises_indication_with_rejoin_flag() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+
+        let leave = Leave {
+            command_options: LeaveCommandOptions(0).set_request(true).set_rejoin(true),
+        };
+        block_on(nlme.handle_nwk_command(&dummy_header(0x0000), Command::Leave(leave)));
+
+        // 3.2.2.19: removed by the parent -> NULL device address; the higher
+        // layer drives the rejoin (3.6.1.10.4 step 1)
+        assert_eq!(
+            nlme.take_leave_indication(),
+            Some(NlmeLeaveIndication {
+                device_address: None,
+                rejoin: true,
+            })
+        );
+    }
+
+    #[test]
+    fn rejoin_after_leave_accepts_the_requested_extended_pan_id() {
+        let mut mac = MockMlme::new();
+        mac.expect_transmit_data().times(1).returning(|_, _| Ok(()));
+        mac.expect_poll_data().returning(|_, buf| {
+            let frame = encrypted_rejoin_response(0x5678, 0x00);
+            buf[..frame.len()].copy_from_slice(&frame);
+            Ok((frame.len(), 200))
+        });
+        mac.expect_configure().times(1).returning(|_| ());
+
+        let (_guard, nlme) = make_nlme(mac);
+        seed_joined_nib(&nlme);
+        // a leave zeroed the extended PAN id (3.6.1.10.1)
+        nlme.nib().update_extended_panid(|value| *value = 0);
+
+        let confirm = block_on(nlme.join(rejoin_request(0xDEAD)));
+
+        assert_eq!(confirm.status, NlmeJoinStatus::Success);
+        assert_eq!(*nlme.nib().extended_panid(), 0xDEAD);
+    }
+
+    /// An encrypted End Device Timeout Response as the parent sends it.
+    fn encrypted_timeout_response(status: u8) -> heapless::Vec<u8, 128> {
+        let nib = nib::get_ref();
+        let header = NwkHeader {
+            frame_control: NwkFrameControl(0)
+                .set_frame_type(NwkFrameType::NwkCommand)
+                .set_protocol_version(2)
+                .set_discover_route(DiscoverRoute::Suppress)
+                .set_security_flag(true)
+                .set_source_ieee_flag(true),
+            destination: ShortAddress(*nib.network_address()),
+            source: ShortAddress(0x0000),
+            radius: 1,
+            sequence_number: 0,
+            destination_ieee: None,
+            source_ieee: Some(*nib.ieee_address()),
+            multicast_control: None,
+            source_route_subframe: None,
+        };
+        let command = Command::EndDeviceTimeoutResponse(EndDeviceTimeoutResponse {
+            status,
+            parent_information: EndDeviceTimeoutResponse::TIMEOUT_REQUEST_KEEPALIVE,
+        });
+        let nwk_frame = NwkFrame::NwkCommand(NwkCommandFrame { header, command });
+        let mut buf = heapless::Vec::<u8, 128>::new();
+        buf.resize(128, 0).unwrap();
+        let len = SecurityContext::get()
+            .encrypt_nwk_frame_in_place(nwk_frame, &mut buf)
+            .unwrap();
+        buf.truncate(len);
+        buf
     }
 }

--- a/zigbee/src/storage/flash.rs
+++ b/zigbee/src/storage/flash.rs
@@ -7,6 +7,7 @@ use embedded_storage_async::nor_flash::NorFlash;
 use sequential_storage::cache::NoCache;
 use sequential_storage::map::MapConfig;
 use sequential_storage::map::MapStorage;
+use zigbee_types::sync::yield_now;
 
 use super::StorageDriver;
 use crate::aps::aib;
@@ -122,6 +123,19 @@ pub async fn init_with_flash<F: NorFlash>(flash: F, range: Range<u32>) -> FlashS
 }
 
 impl<F: NorFlash> StorageDriver for FlashStorage<F> {
+    /// Persists information-base changes as they happen; run this in its own
+    /// task, or let the application runtime drive it.
+    ///
+    /// Wakes whenever a persisted NIB/AIB attribute changes and flushes the
+    /// dirty fields. Counter headroom keeps the actual flash write rate far
+    /// below the change rate.
+    async fn run(&self) {
+        loop {
+            wait_any(nib::changed(), aib::changed()).await;
+            self.flush().await;
+        }
+    }
+
     async fn flush(&self) {
         let mut inner = loop {
             if let Some(inner) = self.inner.try_lock() {
@@ -140,21 +154,6 @@ impl<F: NorFlash> StorageDriver for FlashStorage<F> {
     }
 }
 
-impl<F: NorFlash> FlashStorage<F> {
-    /// Persists information-base changes as they happen; run this in its
-    /// own task.
-    ///
-    /// Wakes whenever a persisted NIB/AIB attribute changes and flushes
-    /// the dirty fields. Counter headroom keeps the actual flash write
-    /// rate far below the change rate.
-    pub async fn run(&self) -> ! {
-        loop {
-            wait_any(nib::changed(), aib::changed()).await;
-            self.flush().await;
-        }
-    }
-}
-
 async fn wait_any(a: impl Future<Output = ()>, b: impl Future<Output = ()>) {
     let mut a = pin!(a);
     let mut b = pin!(b);
@@ -162,20 +161,6 @@ async fn wait_any(a: impl Future<Output = ()>, b: impl Future<Output = ()>) {
         if a.as_mut().poll(cx).is_ready() || b.as_mut().poll(cx).is_ready() {
             Poll::Ready(())
         } else {
-            Poll::Pending
-        }
-    })
-    .await;
-}
-
-async fn yield_now() {
-    let mut yielded = false;
-    poll_fn(|cx| {
-        if yielded {
-            Poll::Ready(())
-        } else {
-            yielded = true;
-            cx.waker().wake_by_ref();
             Poll::Pending
         }
     })

--- a/zigbee/src/storage/mod.rs
+++ b/zigbee/src/storage/mod.rs
@@ -21,6 +21,26 @@
 pub trait StorageDriver {
     /// Persists all information-base fields modified since the last call.
     async fn flush(&self);
+
+    /// Persists information-base changes as they happen, until cancelled.
+    ///
+    /// Drivers that write in the background implement this; the default never
+    /// completes, so a caller can drive any driver the same way.
+    async fn run(&self) {
+        core::future::pending::<()>().await;
+    }
+}
+
+/// Lets a driver be shared: the stack can hold a reference to one the
+/// application also flushes itself.
+impl<T: StorageDriver> StorageDriver for &T {
+    async fn flush(&self) {
+        (**self).flush().await;
+    }
+
+    async fn run(&self) {
+        (**self).run().await;
+    }
 }
 
 /// RAM-only operation: state is lost on reset.

--- a/zigbee/src/zdo/descriptor.rs
+++ b/zigbee/src/zdo/descriptor.rs
@@ -74,7 +74,10 @@ fn append(out: &mut [u8], offset: &mut usize, bytes: &[u8]) -> Result<(), byte::
 }
 
 /// Static configuration of the node descriptor (2.3.2.3).
-#[derive(Debug, Clone, Copy)]
+///
+/// The default describes an end device with no capabilities announced; fill in
+/// what the node actually is.
+#[derive(Debug, Clone, Copy, Default)]
 pub struct NodeDescriptorConfig {
     pub logical_type: LogicalType,
     pub complex_descriptor_available: bool,

--- a/zigbee/src/zdo/mod.rs
+++ b/zigbee/src/zdo/mod.rs
@@ -30,13 +30,19 @@ use crate::aps::frame::Frame;
 use crate::aps::frame::command::Command;
 use crate::aps::frame::command::TransportKey;
 use crate::aps::types::TxOptions;
+use crate::nwk::frame::command::network_status::NetworkStatusCode;
 use crate::nwk::nib;
 use crate::nwk::nib::NWK_BROADCAST_ADDRESS_MIN;
 use crate::nwk::nib::NetworkSecurityMaterialDescriptor;
+use crate::nwk::nlme::KeepaliveMethod;
 use crate::nwk::nlme::NetworkError;
 use crate::nwk::nlme::Nlme;
+use crate::nwk::nlme::management::NlmeJoinConfirm;
+use crate::nwk::nlme::management::NlmeJoinRequest;
+use crate::nwk::nlme::management::NlmeJoinStatus;
 use crate::nwk::nlme::management::NlmeLeaveRequest;
 use crate::nwk::nlme::management::NlmeLeaveStatus;
+use crate::nwk::nlme::management::RejoinNetwork;
 use crate::security::SecurityContext;
 
 // number of MAC poll attempts when waiting for the Trust Center to deliver the
@@ -62,6 +68,8 @@ pub struct ZigbeeDevice<M> {
     // carries an inbound Node_Desc_rsp (2.4.4.2.3) to the procedure that
     // asked for it, e.g. the BDB TC link key exchange
     node_desc_rsp: Signal<descriptor::NodeDescRsp>,
+    // set when a leave asked this device to rejoin (3.6.1.10.4 step 1)
+    rejoin_requested: Event,
 }
 
 /// zigbee network
@@ -93,7 +101,7 @@ pub struct ClusterRequest<'a> {
 /// Handler for inbound application-profile (non-ZDP) requests.
 ///
 /// Implemented by cluster servers (e.g. the ZCL Basic cluster) to answer
-/// requests delivered to the [`ZigbeeDevice::rx_loop`]. Takes `&self` so it can
+/// requests delivered by a receive loop. Takes `&self` so it can
 /// be shared with the receive task.
 pub trait ClusterRequestHandler {
     /// Build a response ASDU for an application-profile request, writing it
@@ -112,7 +120,7 @@ impl<T: ClusterRequestHandler + ?Sized> ClusterRequestHandler for &T {
 /// Chains two handlers: the first to produce a response wins. Lets an
 /// application compose independent cluster servers (e.g. Basic-cluster reads
 /// plus a generic reporting responder) into the single handler
-/// [`ZigbeeDevice::rx_loop`] expects.
+/// a receive loop expects.
 impl<A: ClusterRequestHandler, B: ClusterRequestHandler> ClusterRequestHandler for (A, B) {
     fn handle(&self, request: &ClusterRequest<'_>, out: &mut [u8]) -> Option<usize> {
         self.0
@@ -143,6 +151,7 @@ impl<M: Mlme> ZigbeeDevice<M> {
             zdp_seq: AtomicU8::new(0),
             joined: Event::new(),
             node_desc_rsp: Signal::new(),
+            rejoin_requested: Event::new(),
         }
     }
 
@@ -372,6 +381,87 @@ impl<M: Mlme> ZigbeeDevice<M> {
         device_annce::broadcast(&self.nlme, &self.apsme, self.next_zdp_seq(), annce).await
     }
 
+    /// Broadcast a ZDO Device_annce for this device (2.4.3.1.11), announcing
+    /// the addresses it holds after a join or rejoin.
+    pub async fn announce_self(&self) -> Result<(), NetworkError> {
+        let nib = nib::get_ref();
+        let annce = device_annce::DeviceAnnce {
+            nwk_addr: ShortAddress(*nib.network_address()),
+            ieee_addr: *nib.ieee_address(),
+            capability: *nib.capability_information(),
+        };
+        self.device_annce(annce).await
+    }
+
+    /// Network Manager (2.5.2.4): rejoin the network after communication with
+    /// it was lost.
+    ///
+    /// A Secure Rejoin is attempted first — it secures the Rejoin Request with
+    /// the active network key and completes in a single exchange. If that
+    /// fails, typically because a network key update was missed, a Trust
+    /// Center rejoin follows: the request goes out unsecured and the current
+    /// network key is obtained from the Trust Center (3.6.10.10, 4.6.3.3.2).
+    /// Both keep the Trust Center link key, so neither needs re-commissioning.
+    ///
+    /// The remembered parent is addressed first; if it does not answer,
+    /// `channels` are scanned for another router of the same network
+    /// (3.6.1.4.2). On success the end-device timeout is renegotiated
+    /// (3.6.10.2) and the device announces itself again.
+    ///
+    /// `extended_pan_id` names the network to return to: a leave zeroes
+    /// `nwkExtendedPANId` (3.6.1.10.1), so it cannot always be read back from
+    /// the NIB.
+    pub async fn rejoin(
+        &self,
+        extended_pan_id: IeeeAddress,
+        channels: core::ops::Range<u8>,
+        scan_duration: u8,
+    ) -> Result<NlmeJoinConfirm, NetworkError> {
+        let capability_information = *nib::get_ref().capability_information();
+        let request = |security_enabled| NlmeJoinRequest {
+            extended_pan_id,
+            rejoin_network: RejoinNetwork::NwkRejoin,
+            capability_information,
+            security_enabled,
+            scan_channels: channels.clone(),
+            scan_duration,
+        };
+
+        log::debug!("[ZDO] secure rejoin, EPID={extended_pan_id:?}");
+        let confirm = self.nlme.join(request(true)).await;
+        if confirm.status == NlmeJoinStatus::Success {
+            self.finish_rejoin().await?;
+            return Ok(confirm);
+        }
+
+        log::warn!(
+            "[ZDO] secure rejoin failed ({:?}), falling back to trust center rejoin",
+            confirm.status
+        );
+        let confirm = self.nlme.join(request(false)).await;
+        if confirm.status != NlmeJoinStatus::Success {
+            log::warn!("[ZDO] trust center rejoin failed ({:?})", confirm.status);
+            return Ok(confirm);
+        }
+
+        // 4.6.3.3.2: the unsecured rejoin leaves the device without a valid
+        // network key until the Trust Center transports the current one
+        self.poll_transport_key().await?;
+        self.finish_rejoin().await?;
+        Ok(confirm)
+    }
+
+    // pick up where a successful rejoin leaves off: the receive loop was
+    // parked by the leave or the link failure, the timeout is renegotiated
+    // with the (possibly new) parent, and the network is told which addresses
+    // this device holds now
+    async fn finish_rejoin(&self) -> Result<(), NetworkError> {
+        self.mark_rejoined();
+        // 3.6.10.2: renegotiated after every rejoin, even with the same parent
+        let _ = self.nlme.negotiate_end_device_timeout().await;
+        self.announce_self().await
+    }
+
     /// Security Manager: poll for a Transport-Key command and install the
     /// network key and Trust Center link key entry (4.4.10).
     ///
@@ -497,6 +587,38 @@ impl<M: Mlme> ZigbeeDevice<M> {
             indication.rejoin
         );
         self.mark_joined(false);
+        // 3.6.1.10.4 step 1: a leave with the rejoin flag keeps the NIB and
+        // asks the device back onto the network — the higher layer drives it
+        if indication.rejoin {
+            self.rejoin_requested.signal();
+        }
+    }
+
+    /// Whether a leave asked this device to rejoin the network (3.6.1.10.4).
+    ///
+    /// Consumes the request: the receive loop is parked until the higher layer
+    /// rejoins and calls [`Self::mark_rejoined`].
+    pub fn take_rejoin_request(&self) -> bool {
+        if !self.rejoin_requested.is_set() {
+            return false;
+        }
+        self.rejoin_requested.reset();
+        true
+    }
+
+    /// Wait until a leave asks this device to rejoin the network
+    /// (3.6.1.10.4).
+    pub async fn wait_rejoin_request(&self) {
+        self.rejoin_requested.wait().await;
+    }
+
+    /// Re-open the receive loop's join gate after the higher layer rejoined
+    /// the network.
+    ///
+    /// A leave with the rejoin flag, or a lost parent link, parks the loop
+    /// until the device is back on the network.
+    pub fn mark_rejoined(&self) {
+        self.mark_joined(true);
     }
 
     /// Arm the TC link key exchange (BDB 10.2.5): key-transport commands
@@ -1053,61 +1175,13 @@ impl<M: Mlme> ZigbeeDevice<M> {
         };
         Some(result)
     }
-
-    /// Run the receive/dispatch loop forever (the steady-state RX task).
-    ///
-    /// Waits for the join to complete before touching the radio, so it can
-    /// be spawned ahead of commissioning. The receive strategy follows the
-    /// joined capability (`nwkCapabilityInformation`, 3.4.1.3.1.1): a device
-    /// with `rxOnWhenIdle = TRUE` listens for frames directly, while a sleepy
-    /// end device polls the parent for buffered unicasts every
-    /// `poll_interval_ms` — keep it below the parent's indirect-transaction
-    /// persistence time (~7.68 s).
-    ///
-    /// A leave takes the device off the network and parks the loop until it
-    /// has been re-commissioned.
-    pub async fn rx_loop(
-        &self,
-        cfg: &descriptor::DeviceDescriptorConfig<'_>,
-        handler: &impl ClusterRequestHandler,
-        delay: &mut impl DelayNs,
-        poll_interval_ms: u32,
-    ) -> ! {
-        // a restored network address means the device resumed on a network
-        // without a fresh key exchange — release the gate immediately
-        if *self.nlme.nib().network_address() != ShortAddress::default().0 {
-            self.mark_joined(true);
-        }
-        self.wait_until_joined().await;
-        if self
-            .nlme
-            .nib()
-            .capability_information()
-            .receiver_on_when_idle()
-        {
-            loop {
-                // dispatching a leave closes the gate again, parking the loop
-                // until the higher layer has re-commissioned
-                self.wait_until_joined().await;
-                if let Err(e) = self.receive_and_dispatch(cfg, handler).await {
-                    log::debug!("[ZDO] rx dispatch error: {e:?}");
-                }
-            }
-        }
-        loop {
-            self.wait_until_joined().await;
-            if let Err(e) = self.poll_and_dispatch(cfg, handler).await {
-                log::debug!("[ZDO] rx dispatch error: {e:?}");
-            }
-            delay.delay_ms(poll_interval_ms).await;
-        }
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use zigbee_mac::Address;
     use zigbee_mac::mlme::AssociationResponse;
+    use zigbee_mac::mlme::MacConfig;
     use zigbee_mac::mlme::MacError;
     use zigbee_mac::mlme::ScanResult;
     use zigbee_mac::mlme::ScanType;
@@ -1131,7 +1205,7 @@ mod tests {
         Mlme {}
         impl Mlme for Mlme {
             fn ieee_address(&self) -> IeeeAddress;
-            async fn set_short_address(&self, address: ShortAddress);
+            async fn configure(&self, config: MacConfig);
             async fn scan_network(
                 &self,
                 ty: ScanType,


### PR DESCRIPTION
* fix keepalive including periodic keepalive pings to parents
* refactor: make the create more usable by creating a crate combining all required components of the stack (ZDO, BDB, Storage, etc.) into one `Stack` instance